### PR TITLE
Add initial Alembic migration and rewrite SQLAlchemy seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ flask db init                      # primera vez
 flask db migrate -m "init"
 flask db upgrade
 
-# (Opcional) Seeds
+# (Opcional) Seeds (reinicia datos base)
 python seeds/seed.py
 
 # Ejecutar
@@ -187,11 +187,13 @@ flask db migrate -m "cambio X"
 flask db upgrade
 ```
 
-Seeds (`seeds/seed.py`): crea hospitales (Lucio Molas, René Favaloro), servicios/oficinas, usuarios base:
+El repositorio incluye una migración inicial con todas las tablas declaradas en `app/models`. El comando `flask db upgrade` tomará la URL configurada en `DATABASE_URL` (o el valor por defecto de `config.py`).
+
+Seeds (`seeds/seed.py`): abre una sesión SQLAlchemy sobre `DATABASE_URL`, limpia los datos existentes y vuelve a poblar la base con hospitales (Lucio Molas, René Favaloro), usuarios base, permisos por módulo/hospital, inventario de ejemplo (equipos + insumos) y licencias en distintos estados:
 
 - `admin / 123456` (Superadmin)
 - Admin y Técnico por hospital (con permisos de módulos diferenciados)
-- Equipos/insumos/actas/docscan/licencias de ejemplo
+- Equipos/insumos/actas/adjuntos/licencias de ejemplo
 - Asegura que los permisos por hospital y módulo queden cargados.
 
 ## 7. Roles, permisos y seguridad

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,8 +1,41 @@
 from __future__ import with_statement
 
+from logging.config import fileConfig
+import os
+import sys
+from pathlib import Path
+
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
+# Ensure the application package is importable when Alembic runs from the
+# ``migrations`` directory.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - configuration hook
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from config import Config
+
+
+# Import the SQLAlchemy models so the metadata includes every table defined in
+# ``app.models``.  Alembic's autogenerate feature relies on this metadata to
+# compare the declared schema with the actual database.
+from app.models.base import Base
+
+# Importing the modules registers their tables on ``Base.metadata``.
+from app.models import (  # noqa: F401  - imported for side effects
+    acta,
+    adjunto,
+    auditoria,
+    docscan,
+    equipo,
+    hospital,
+    insumo,
+    licencia,
+    permisos,
+    rol,
+    usuario,
+)
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -13,13 +46,13 @@ config = context.config
 if config.config_file_name is not None:  # pragma: no cover - configuration hook
     fileConfig(config.config_file_name)
 
-# Add your model's MetaData object here for 'autogenerate' support
-# from app.models import Base
-# target_metadata = Base.metadata
+# Configure the SQLAlchemy URL from the environment (if provided) or fall back
+# to the application's default database URI.
+database_url = os.getenv("DATABASE_URL", Config.SQLALCHEMY_DATABASE_URI)
+config.set_main_option("sqlalchemy.url", database_url)
 
-# In this simplified example we do not have SQLAlchemy models
-# so target_metadata remains None.
-target_metadata = None
+# Use the project's declarative ``Base`` metadata for autogeneration support.
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:

--- a/migrations/versions/c28f3d5aa8a9_initial_schema.py
+++ b/migrations/versions/c28f3d5aa8a9_initial_schema.py
@@ -1,0 +1,301 @@
+"""Initial database schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c28f3d5aa8a9"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+# Enumerated types reused across multiple tables. Defining them once allows us
+# to create and drop them explicitly during migrations which keeps PostgreSQL
+# databases tidy when downgrading.
+modulo_permiso_enum = sa.Enum(
+    "inventario",
+    "insumos",
+    "actas",
+    "adjuntos",
+    "docscan",
+    "reportes",
+    "auditoria",
+    "licencias",
+    name="modulo_permiso",
+)
+
+tipo_equipo_enum = sa.Enum(
+    "impresora",
+    "router",
+    "switch",
+    "notebook",
+    "cpu",
+    "monitor",
+    "access_point",
+    "scanner",
+    "proyector",
+    "telefono_ip",
+    "ups",
+    "otro",
+    name="tipo_equipo",
+)
+
+estado_equipo_enum = sa.Enum(
+    "operativo",
+    "servicio_tecnico",
+    "de_baja",
+    name="estado_equipo",
+)
+
+tipo_acta_enum = sa.Enum(
+    "entrega",
+    "prestamo",
+    "transferencia",
+    name="tipo_acta",
+)
+
+tipo_adjunto_enum = sa.Enum(
+    "factura",
+    "presupuesto",
+    "acta",
+    "planilla_patrimonial",
+    "otro",
+    name="tipo_adjunto",
+)
+
+tipo_docscan_enum = sa.Enum(
+    "nota",
+    "informe",
+    "otro",
+    name="tipo_docscan",
+)
+
+tipo_licencia_enum = sa.Enum(
+    "temporal",
+    "permanente",
+    name="tipo_licencia",
+)
+
+estado_licencia_enum = sa.Enum(
+    "borrador",
+    "pendiente",
+    "aprobada",
+    "rechazada",
+    name="estado_licencia",
+)
+
+
+def upgrade() -> None:
+    modulo_permiso_enum.create(op.get_bind(), checkfirst=True)
+    tipo_equipo_enum.create(op.get_bind(), checkfirst=True)
+    estado_equipo_enum.create(op.get_bind(), checkfirst=True)
+    tipo_acta_enum.create(op.get_bind(), checkfirst=True)
+    tipo_adjunto_enum.create(op.get_bind(), checkfirst=True)
+    tipo_docscan_enum.create(op.get_bind(), checkfirst=True)
+    tipo_licencia_enum.create(op.get_bind(), checkfirst=True)
+    estado_licencia_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "hospitales",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("nombre", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("nombre", sa.String(length=50), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("nombre"),
+    )
+
+    op.create_table(
+        "usuarios",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("nombre", sa.String(length=100), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("rol_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["rol_id"], ["roles.id"], name="usuarios_rol_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+    op.create_table(
+        "insumos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("nombre", sa.String(length=100), nullable=False),
+        sa.Column("numero_serie", sa.String(length=100), nullable=True),
+        sa.Column("stock", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_insumos_numero_serie", "insumos", ["numero_serie"], unique=False)
+
+    op.create_table(
+        "equipos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tipo", tipo_equipo_enum, nullable=False),
+        sa.Column(
+            "estado",
+            estado_equipo_enum,
+            nullable=False,
+            server_default=sa.text("'operativo'"),
+        ),
+        sa.Column("descripcion", sa.String(length=255), nullable=True),
+        sa.Column("numero_serie", sa.String(length=100), nullable=True),
+        sa.Column("hospital_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="equipos_hospital_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_equipos_hospital_id", "equipos", ["hospital_id"], unique=False)
+    op.create_index("ix_equipos_numero_serie", "equipos", ["numero_serie"], unique=False)
+
+    op.create_table(
+        "actas",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tipo", tipo_acta_enum, nullable=False),
+        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), nullable=True),
+        sa.Column("hospital_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="actas_hospital_id_fkey"),
+        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="actas_usuario_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "adjuntos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("equipo_id", sa.Integer(), nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("tipo", tipo_adjunto_enum, nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="adjuntos_equipo_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_adjuntos_equipo_id", "adjuntos", ["equipo_id"], unique=False)
+
+    op.create_table(
+        "docscan",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tipo", tipo_docscan_enum, nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="docscan_usuario_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "permisos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("rol_id", sa.Integer(), nullable=False),
+        sa.Column("modulo", modulo_permiso_enum, nullable=False),
+        sa.Column("hospital_id", sa.Integer(), nullable=True),
+        sa.Column("can_read", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("can_write", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="permisos_hospital_id_fkey"),
+        sa.ForeignKeyConstraint(["rol_id"], ["roles.id"], name="permisos_rol_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_permisos_hospital_id", "permisos", ["hospital_id"], unique=False)
+    op.create_index("ix_permisos_rol_id", "permisos", ["rol_id"], unique=False)
+
+    op.create_table(
+        "licencias",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), nullable=True),
+        sa.Column("tipo", tipo_licencia_enum, nullable=False),
+        sa.Column("estado", estado_licencia_enum, nullable=False),
+        sa.Column("requires_replacement", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="licencias_hospital_id_fkey"),
+        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="licencias_usuario_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_licencias_hospital_id", "licencias", ["hospital_id"], unique=False)
+    op.create_index("ix_licencias_usuario_id", "licencias", ["usuario_id"], unique=False)
+    op.create_index(
+        "ix_licencias_estado_tipo",
+        "licencias",
+        ["estado", "tipo"],
+        unique=False,
+    )
+
+    op.create_table(
+        "auditoria",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), nullable=True),
+        sa.Column("accion", sa.String(length=100), nullable=False),
+        sa.Column("tabla", sa.String(length=100), nullable=True),
+        sa.Column("registro_id", sa.Integer(), nullable=True),
+        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="auditoria_usuario_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "acta_items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("acta_id", sa.Integer(), nullable=False),
+        sa.Column("equipo_id", sa.Integer(), nullable=False),
+        sa.Column("descripcion", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["acta_id"], ["actas.id"], name="acta_items_acta_id_fkey"),
+        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="acta_items_equipo_id_fkey"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_acta_items_acta_id", "acta_items", ["acta_id"], unique=False)
+    op.create_index("ix_acta_items_equipo_id", "acta_items", ["equipo_id"], unique=False)
+
+    op.create_table(
+        "equipo_insumos",
+        sa.Column("equipo_id", sa.Integer(), nullable=False),
+        sa.Column("insumo_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="equipo_insumos_equipo_id_fkey"),
+        sa.ForeignKeyConstraint(["insumo_id"], ["insumos.id"], name="equipo_insumos_insumo_id_fkey"),
+        sa.PrimaryKeyConstraint("equipo_id", "insumo_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("equipo_insumos")
+    op.drop_index("ix_acta_items_equipo_id", table_name="acta_items")
+    op.drop_index("ix_acta_items_acta_id", table_name="acta_items")
+    op.drop_table("acta_items")
+    op.drop_table("auditoria")
+    op.drop_index("ix_licencias_estado_tipo", table_name="licencias")
+    op.drop_index("ix_licencias_usuario_id", table_name="licencias")
+    op.drop_index("ix_licencias_hospital_id", table_name="licencias")
+    op.drop_table("licencias")
+    op.drop_index("ix_permisos_rol_id", table_name="permisos")
+    op.drop_index("ix_permisos_hospital_id", table_name="permisos")
+    op.drop_table("permisos")
+    op.drop_table("docscan")
+    op.drop_index("ix_adjuntos_equipo_id", table_name="adjuntos")
+    op.drop_table("adjuntos")
+    op.drop_table("actas")
+    op.drop_index("ix_equipos_numero_serie", table_name="equipos")
+    op.drop_index("ix_equipos_hospital_id", table_name="equipos")
+    op.drop_table("equipos")
+    op.drop_index("ix_insumos_numero_serie", table_name="insumos")
+    op.drop_table("insumos")
+    op.drop_table("usuarios")
+    op.drop_table("roles")
+    op.drop_table("hospitales")
+
+    estado_licencia_enum.drop(op.get_bind(), checkfirst=True)
+    tipo_licencia_enum.drop(op.get_bind(), checkfirst=True)
+    tipo_docscan_enum.drop(op.get_bind(), checkfirst=True)
+    tipo_adjunto_enum.drop(op.get_bind(), checkfirst=True)
+    tipo_acta_enum.drop(op.get_bind(), checkfirst=True)
+    estado_equipo_enum.drop(op.get_bind(), checkfirst=True)
+    tipo_equipo_enum.drop(op.get_bind(), checkfirst=True)
+    modulo_permiso_enum.drop(op.get_bind(), checkfirst=True)

--- a/seeds/seed.py
+++ b/seeds/seed.py
@@ -1,23 +1,264 @@
-"""Simple seed script to load JSON fixtures."""
+"""Database seed script that loads core catalogues and sample data."""
 from __future__ import annotations
 
-import json
-from pathlib import Path
+import os
 
-FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import Session
+
+from config import Config
+from app.models.acta import Acta, ActaItem, TipoActa
+from app.models.adjunto import Adjunto, TipoAdjunto
+from app.models.auditoria import Auditoria
+from app.models.equipo import Equipo, EstadoEquipo, TipoEquipo
+from app.models.hospital import Hospital
+from app.models.insumo import Insumo, equipo_insumos
+from app.models.licencia import EstadoLicencia, Licencia, TipoLicencia
+from app.models.permisos import Modulo, Permiso
+from app.models.rol import Rol
+from app.models.usuario import Usuario
 
 
-def load_fixtures() -> None:
-    """Load every JSON file in the fixtures directory.
+def get_engine_url() -> str:
+    """Return the database URL configured for the application."""
 
-    This script does not integrate with a database. It simply demonstrates how
-    fixtures might be processed and is intended as a placeholder for real seed
-    logic.
-    """
-    for fixture in FIXTURES_DIR.glob("*.json"):
-        data = json.loads(fixture.read_text())
-        print(f"Loaded {fixture.name}: {len(data)} records")
+    return os.getenv("DATABASE_URL", Config.SQLALCHEMY_DATABASE_URI)
+
+
+def reset_tables(session: Session) -> None:
+    """Clear existing data so the seed script can be re-run safely."""
+
+    # Delete child tables first to avoid foreign key violations.
+    session.execute(delete(ActaItem))
+    session.execute(delete(Acta))
+    session.execute(delete(Adjunto))
+    session.execute(delete(Auditoria))
+    session.execute(delete(Permiso))
+    session.execute(delete(Licencia))
+    session.execute(delete(equipo_insumos))
+    session.execute(delete(Equipo))
+    session.execute(delete(Insumo))
+    session.execute(delete(Usuario))
+    session.execute(delete(Rol))
+    session.execute(delete(Hospital))
+
+
+def create_catalogs(session: Session) -> dict[str, object]:
+    """Insert hospitals, roles and core catalogues."""
+
+    hospitales = [
+        Hospital(nombre="Hospital Dr. Lucio Molas"),
+        Hospital(nombre="Hospital René Favaloro"),
+    ]
+    roles = [
+        Rol(nombre="Superadmin"),
+        Rol(nombre="Admin"),
+        Rol(nombre="Tecnico"),
+    ]
+    session.add_all(hospitales + roles)
+    session.flush()
+
+    return {
+        "hospitales": hospitales,
+        "roles": {role.nombre.lower(): role for role in roles},
+    }
+
+
+def create_users(session: Session, roles: dict[str, Rol]) -> dict[str, Usuario]:
+    """Create base application users linked to their roles."""
+
+    usuarios = {
+        "superadmin": Usuario(
+            nombre="Super Administrador",
+            email="superadmin@salud.gob.ar",
+            rol=roles["superadmin"],
+        ),
+        "admin_molas": Usuario(
+            nombre="Admin Molas",
+            email="admin.molas@salud.gob.ar",
+            rol=roles["admin"],
+        ),
+        "admin_favaloro": Usuario(
+            nombre="Admin Favaloro",
+            email="admin.favaloro@salud.gob.ar",
+            rol=roles["admin"],
+        ),
+        "tecnico_molas": Usuario(
+            nombre="Tecnico Molas",
+            email="tecnico.molas@salud.gob.ar",
+            rol=roles["tecnico"],
+        ),
+        "tecnico_favaloro": Usuario(
+            nombre="Tecnico Favaloro",
+            email="tecnico.favaloro@salud.gob.ar",
+            rol=roles["tecnico"],
+        ),
+    }
+    session.add_all(usuarios.values())
+    session.flush()
+    return usuarios
+
+
+def create_permissions(session: Session, roles: dict[str, Rol], hospitales: list[Hospital]) -> None:
+    """Generate role/hospital permissions reflecting the documented matrix."""
+
+    permisos: list[Permiso] = []
+
+    # Superadmin has full access across all modules without restricting to a hospital.
+    for modulo in Modulo:
+        permisos.append(
+            Permiso(
+                rol=roles["superadmin"],
+                modulo=modulo,
+                hospital=None,
+                can_read=True,
+                can_write=True,
+            )
+        )
+
+    # Admin role: full management but scoped per hospital.
+    admin_modules = [
+        Modulo.INVENTARIO,
+        Modulo.INSUMOS,
+        Modulo.ACTAS,
+        Modulo.ADJUNTOS,
+        Modulo.LICENCIAS,
+        Modulo.REPORTES,
+    ]
+    for hospital in hospitales:
+        for modulo in admin_modules:
+            permisos.append(
+                Permiso(
+                    rol=roles["admin"],
+                    modulo=modulo,
+                    hospital=hospital,
+                    can_read=True,
+                    can_write=True,
+                )
+            )
+
+    # Técnicos: operación diaria con permisos de lectura y carga básica.
+    tecnico_modules = [Modulo.INVENTARIO, Modulo.INSUMOS, Modulo.ADJUNTOS, Modulo.DOCSCAN]
+    for hospital in hospitales:
+        for modulo in tecnico_modules:
+            permisos.append(
+                Permiso(
+                    rol=roles["tecnico"],
+                    modulo=modulo,
+                    hospital=hospital,
+                    can_read=True,
+                    can_write=modulo in {Modulo.INVENTARIO, Modulo.ADJUNTOS},
+                )
+            )
+
+    session.add_all(permisos)
+
+
+def create_inventory(session: Session, hospitales: list[Hospital]) -> dict[str, object]:
+    """Populate sample inventory (equipos e insumos)."""
+
+    equipos = [
+        Equipo(
+            tipo=TipoEquipo.NOTEBOOK,
+            estado=EstadoEquipo.OPERATIVO,
+            descripcion="Notebook Lenovo ThinkPad",
+            numero_serie="NB-0001",
+            hospital=hospitales[0],
+        ),
+        Equipo(
+            tipo=TipoEquipo.IMPRESORA,
+            estado=EstadoEquipo.SERVICIO_TECNICO,
+            descripcion="Impresora HP LaserJet en revisión",
+            numero_serie="PR-042",
+            hospital=hospitales[1],
+        ),
+    ]
+
+    insumos = [
+        Insumo(nombre="Tóner 85A", numero_serie="TN-85A", stock=12),
+        Insumo(nombre="Cable de red CAT6", numero_serie="CB-100", stock=30),
+    ]
+    session.add_all(equipos + insumos)
+    session.flush()
+
+    # Asociar insumos a los equipos.
+    equipos[0].insumos.append(insumos[1])  # Notebook con cable de red de repuesto.
+    equipos[1].insumos.append(insumos[0])  # Impresora con tóner asignado.
+
+    # Generar un acta de entrega vinculada al equipo operativo.
+    acta = Acta(tipo=TipoActa.ENTREGA, usuario_id=None, hospital=hospitales[0])
+    acta.items.append(
+        ActaItem(
+            equipo=equipos[0],
+            descripcion="Entrega de notebook operativa para el área administrativa.",
+        )
+    )
+    session.add(acta)
+
+    # Documentos de respaldo y auditoría básica.
+    adjunto = Adjunto(
+        equipo=equipos[0],
+        filename="factura_notebook.pdf",
+        tipo=TipoAdjunto.FACTURA,
+    )
+    auditoria = Auditoria(
+        usuario_id=None,
+        accion="Carga inicial de inventario",
+        tabla="equipos",
+        registro_id=equipos[0].id,
+    )
+    session.add_all([adjunto, auditoria])
+
+    return {"equipos": equipos, "insumos": insumos}
+
+
+def create_licenses(session: Session, usuarios: dict[str, Usuario], hospitales: list[Hospital]) -> None:
+    """Create sample licenses to exercise workflow states."""
+
+    licencias = [
+        Licencia(
+            usuario=usuarios["admin_molas"],
+            hospital=hospitales[0],
+            tipo=TipoLicencia.PERMANENTE,
+            estado=EstadoLicencia.APROBADA,
+            requires_replacement=False,
+        ),
+        Licencia(
+            usuario=usuarios["tecnico_favaloro"],
+            hospital=hospitales[1],
+            tipo=TipoLicencia.TEMPORAL,
+            estado=EstadoLicencia.PENDIENTE,
+            requires_replacement=True,
+        ),
+        Licencia(
+            usuario=usuarios["tecnico_molas"],
+            hospital=hospitales[0],
+            tipo=TipoLicencia.TEMPORAL,
+            estado=EstadoLicencia.BORRADOR,
+            requires_replacement=False,
+        ),
+    ]
+
+    session.add_all(licencias)
+
+
+def seed() -> None:
+    """Execute the full seed workflow."""
+
+    engine = create_engine(get_engine_url(), future=True)
+    with Session(engine) as session:
+        with session.begin():
+            reset_tables(session)
+        with session.begin():
+            context = create_catalogs(session)
+            usuarios = create_users(session, context["roles"])
+            create_permissions(session, context["roles"], context["hospitales"])
+            create_inventory(session, context["hospitales"])
+            create_licenses(session, usuarios, context["hospitales"])
+
+    engine.dispose()
+    print("Base de datos poblada con datos iniciales.")
 
 
 if __name__ == "__main__":
-    load_fixtures()
+    seed()


### PR DESCRIPTION
## Summary
- expose the declarative Base metadata to Alembic and configure the database URL from the environment
- add the initial migration that creates all hospital inventory tables and supporting enums
- rewrite the seed script to populate hospitals, roles, permissions, sample inventory and licenses, updating the README instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd39d87d24832496b8707021dfdef6