### PR TITLE
Integrate real Flask app factory for authentication tests

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -37,6 +37,29 @@ class User:
     roles: Set[str] = field(default_factory=set)
     permissions: Set[str] = field(default_factory=set)
 
+    @property
+    def is_authenticated(self) -> bool:
+        """Users provided by the in-memory table are always authenticated."""
+
+        return True
+
+    @property
+    def is_active(self) -> bool:
+        """All in-memory users are active by definition."""
+
+        return True
+
+    @property
+    def is_anonymous(self) -> bool:
+        """The application never treats these users as anonymous."""
+
+        return False
+
+    def get_id(self) -> str:
+        """Return the unique identifier stored in Flask's session."""
+
+        return self.username
+
     @staticmethod
     def _hash_password(password: str) -> str:
         """Return a stable hash for the provided password."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from app import create_app
 @pytest.fixture()
 def app():
     app = create_app()
-    app.config.update(TESTING=True)
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
     return app
 
 


### PR DESCRIPTION
## Summary
- replace the test-only stub with a Flask application factory that initialises extensions, registers blueprints, exposes an `index` endpoint and wires the login manager to the in-memory users
- extend the lightweight `User` model with the attributes Flask-Login expects so the real login flow works during tests
- disable CSRF in the auth tests so they can exercise the real Flask `test_client`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd39d71a10832487ac60fb78c3c439