### PR TITLE
Corrige manejo de descargas y formularios

### DIFF
--- a/app/templates/_form_helpers.html
+++ b/app/templates/_form_helpers.html
@@ -14,8 +14,13 @@
   </div>
 {%- endmacro %}
 
-{% macro render_select(field, form_group_class='mb-3', label_class='form-label', extra_attrs=None) -%}
-  {{ render_field(field, form_group_class=form_group_class, label_class=label_class, input_class='form-select', extra_attrs=extra_attrs) }}
+{% macro render_select(field, form_group_class='mb-3', label_class='form-label', input_class='form-select', multiple=None, size=None, extra_attrs=None, class_=None) -%}
+  {% set select_class = input_class %}
+  {% if class_ %}
+    {% set select_class = input_class ~ ' ' ~ class_ %}
+  {% endif %}
+  {% set attrs = build_select_attrs(field, multiple=multiple, size=size, extra_attrs=extra_attrs) %}
+  {{ render_field(field, form_group_class=form_group_class, label_class=label_class, input_class=select_class|trim, extra_attrs=attrs) }}
 {%- endmacro %}
 
 {% macro render_textarea(field, form_group_class='mb-3', label_class='form-label', input_class='form-control', rows=3, help_text=None, extra_attrs=None) -%}

--- a/app/templates/adjuntos/listar.html
+++ b/app/templates/adjuntos/listar.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% extends 'base.html' %}
 {% from '_pagination.html' import render_pagination %}
 {% block title %}Adjuntos{% endblock %}
 {% block content %}

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Página no encontrada{% endblock %}
+{% block content %}
+<div class="text-center py-5">
+  <h1 class="display-5 fw-bold">404</h1>
+  <p class="lead">No encontramos la página o el recurso solicitado.</p>
+  <a class="btn btn-primary" href="{{ url_for('main.index') }}">Volver al inicio</a>
+</div>
+{% endblock %}

--- a/app/templates/licencias/listar.html
+++ b/app/templates/licencias/listar.html
@@ -47,7 +47,11 @@
         <td class="text-end">
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('licencias.detalle', licencia_id=licencia.id) }}">Detalle</a>
           {% if current_user.has_role('Superadmin') or current_user.has_role('Admin') %}
-          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('licencias.aprobar_rechazar', licencia_id=licencia.id) }}">Gestionar</a>
+            {% if licencia.estado == estados.PENDIENTE %}
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('licencias.aprobar_rechazar', licencia_id=licencia.id) }}">Gestionar</a>
+            {% else %}
+              <button class="btn btn-sm btn-outline-secondary" type="button" disabled>Gestionada</button>
+            {% endif %}
           {% endif %}
         </td>
       </tr>

--- a/app/templates/licencias/solicitar.html
+++ b/app/templates/licencias/solicitar.html
@@ -1,6 +1,4 @@
 {% extends 'base.html' %}
-{% block title %}Solicitar licencia{% endblock %}
-{% extends 'base.html' %}
 {% from '_form_helpers.html' import render_checkbox, render_field, render_select, render_textarea %}
 {% block title %}Solicitar licencia{% endblock %}
 {% block content %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers exposed to the Flask app."""
 
-from .forms import render_input_field
+from .forms import build_select_attrs, render_input_field
 
-__all__ = ["render_input_field"]
+__all__ = ["render_input_field", "build_select_attrs"]

--- a/app/utils/forms.py
+++ b/app/utils/forms.py
@@ -39,4 +39,29 @@ def render_input_field(
     return Markup(field(**attrs))
 
 
-__all__ = ["render_input_field"]
+def build_select_attrs(
+    field: Any,
+    *,
+    multiple: bool | None = None,
+    size: int | None = None,
+    extra_attrs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a dictionary with normalized attributes for select fields."""
+
+    attrs: dict[str, Any] = dict(extra_attrs or {})
+    is_multiple_field = getattr(field, "type", "") in {
+        "SelectMultipleField",
+        "QuerySelectMultipleField",
+    }
+    if multiple is None:
+        multiple_flag = is_multiple_field
+    else:
+        multiple_flag = multiple
+    if multiple_flag:
+        attrs["multiple"] = "multiple"
+    if size:
+        attrs["size"] = size
+    return attrs
+
+
+__all__ = ["render_input_field", "build_select_attrs"]

--- a/config.py
+++ b/config.py
@@ -31,7 +31,8 @@ class Config:
     REMEMBER_COOKIE_DURATION = timedelta(days=30)
 
     UPLOAD_FOLDER: str = os.getenv("UPLOAD_FOLDER", _default_upload_dir())
-    DOCSCAN_FOLDER: str = os.getenv("DOCSCAN_FOLDER", _default_upload_dir())
+    ADJUNTOS_SUBFOLDER: str = os.getenv("ADJUNTOS_SUBFOLDER", "adjuntos")
+    DOCSCAN_SUBFOLDER: str = os.getenv("DOCSCAN_SUBFOLDER", "docscan")
     MAX_CONTENT_LENGTH: int = int(os.getenv("MAX_CONTENT_LENGTH", 16 * 1024 * 1024))
     ALLOWED_EXTENSIONS: set[str] = set(
         os.getenv("ALLOWED_EXTENSIONS", "pdf,jpg,jpeg,png").split(",")


### PR DESCRIPTION
## Summary
- centraliza la configuración de subcarpetas de uploads y asegura su creación al iniciar la app, incluyendo una vista 404 dedicada
- refactoriza las descargas de adjuntos y docscan para validar rutas y responder con 404 amigable cuando el archivo falta
- mejora la macro de selects, el helper de formularios y las vistas de licencias para soportar selección múltiple y validar estados

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d337e3cc848324ace3f5be34eefab8