### PR TITLE
Add apellido column to usuarios

### DIFF
--- a/migrations/versions/8a9f4ce0f1a7_add_apellido_to_usuarios.py
+++ b/migrations/versions/8a9f4ce0f1a7_add_apellido_to_usuarios.py
@@ -1,0 +1,24 @@
+"""Add apellido column to usuarios.
+
+Revision ID: 8a9f4ce0f1a7
+Revises: c28f3d5aa8a9
+Create Date: 2025-01-14 00:00:00
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "8a9f4ce0f1a7"
+down_revision = "c28f3d5aa8a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("usuarios", sa.Column("apellido", sa.String(length=120), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("usuarios", "apellido")


### PR DESCRIPTION
## Summary
- add a new Alembic migration that introduces an optional `apellido` column on the `usuarios` table
- include downgrade logic to drop the column

## Testing
- flask --app wsgi:app db upgrade
- python seeds/seed.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34f16dddc83248c27a19dd7b5e6fe