### PR TITLE
Add email-validator dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ SQLAlchemy>=2.0
 python-dotenv>=1.0
 gunicorn>=21.2
 pytest>=7.4
+email-validator>=2.1


### PR DESCRIPTION
## Summary
- add email-validator to the Python dependencies so UsuarioForm validation can import email_validator

## Testing
- `pip install -r requirements.txt` *(fails: package cannot be downloaded due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b87891f88324a0f080ef80deed98