### PR TITLE
Implement lookup selectors, serial rules and equipment attachments

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -48,6 +48,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     for key, folder in {
         "ADJUNTOS_UPLOAD_FOLDER": upload_root / app.config.get("ADJUNTOS_SUBFOLDER", "adjuntos"),
         "DOCSCAN_UPLOAD_FOLDER": upload_root / app.config.get("DOCSCAN_SUBFOLDER", "docscan"),
+        "EQUIPOS_UPLOAD_FOLDER": upload_root / app.config.get("EQUIPOS_SUBFOLDER", "equipos"),
     }.items():
         folder.mkdir(parents=True, exist_ok=True)
         app.config[key] = str(folder)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from .auditoria import Auditoria
 from .base import Base
 from .docscan import Docscan, TipoDocscan
 from .equipo import Equipo, EstadoEquipo, TipoEquipo
+from .equipo_adjunto import EquipoAdjunto
 from .hospital import Hospital, Oficina, Servicio
 from .insumo import Insumo, InsumoMovimiento, MovimientoTipo, equipo_insumos
 from .licencia import Licencia, TipoLicencia, EstadoLicencia
@@ -27,6 +28,7 @@ __all__ = [
     "Equipo",
     "EstadoEquipo",
     "TipoEquipo",
+    "EquipoAdjunto",
     "Hospital",
     "Servicio",
     "Oficina",

--- a/app/models/equipo.py
+++ b/app/models/equipo.py
@@ -5,15 +5,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import (
-    Date,
-    DateTime,
-    Enum as SAEnum,
-    ForeignKey,
-    String,
-    Text,
-    func,
-)
+from sqlalchemy import Boolean, Date, DateTime, Enum as SAEnum, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -22,6 +14,7 @@ from .insumo import equipo_insumos
 if TYPE_CHECKING:  # pragma: no cover
     from .acta import ActaItem
     from .adjunto import Adjunto
+    from .equipo_adjunto import EquipoAdjunto
     from .hospital import Hospital, Oficina, Servicio
     from .insumo import Insumo
     from .usuario import Usuario
@@ -70,6 +63,7 @@ class Equipo(Base):
     marca: Mapped[str | None] = mapped_column(String(100))
     modelo: Mapped[str | None] = mapped_column(String(100))
     numero_serie: Mapped[str | None] = mapped_column(String(120), index=True)
+    sin_numero_serie: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     hospital_id: Mapped[int] = mapped_column(ForeignKey("hospitales.id"), nullable=False)
     servicio_id: Mapped[int | None] = mapped_column(ForeignKey("servicios.id"))
     oficina_id: Mapped[int | None] = mapped_column(ForeignKey("oficinas.id"))
@@ -96,6 +90,9 @@ class Equipo(Base):
     )
     acta_items: Mapped[list["ActaItem"]] = relationship("ActaItem", back_populates="equipo")
     adjuntos: Mapped[list["Adjunto"]] = relationship("Adjunto", back_populates="equipo")
+    archivos: Mapped[list["EquipoAdjunto"]] = relationship(
+        "EquipoAdjunto", back_populates="equipo", cascade="all, delete-orphan"
+    )
     historial: Mapped[list["EquipoHistorial"]] = relationship(
         "EquipoHistorial", back_populates="equipo", cascade="all, delete-orphan"
     )

--- a/app/models/equipo_adjunto.py
+++ b/app/models/equipo_adjunto.py
@@ -1,0 +1,36 @@
+"""Binary attachments associated to equipment records."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .equipo import Equipo
+    from .usuario import Usuario
+
+
+class EquipoAdjunto(Base):
+    """Stores uploaded files linked to equipment entries."""
+
+    __tablename__ = "equipos_adjuntos"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    equipo_id: Mapped[int] = mapped_column(ForeignKey("equipos.id"), nullable=False, index=True)
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    filepath: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(120), nullable=False)
+    uploaded_by_id: Mapped[int | None] = mapped_column(ForeignKey("usuarios.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
+    )
+
+    equipo: Mapped["Equipo"] = relationship("Equipo", back_populates="archivos")
+    uploaded_by: Mapped["Usuario | None"] = relationship("Usuario")
+
+
+__all__ = ["EquipoAdjunto"]

--- a/app/routes/api/search.py
+++ b/app/routes/api/search.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 from flask import jsonify, request
 from flask_login import login_required
-from sqlalchemy import asc
+from sqlalchemy import asc, or_
 
-from app.models import Insumo, Oficina, Servicio
+from app.models import Hospital, Insumo, Oficina, Servicio
 
 from . import api_bp
 
 DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 50
+LOOKUP_PAGE_SIZE = 100
 
 
 def _sanitize_query_param() -> str:
@@ -21,6 +22,109 @@ def _sanitize_query_param() -> str:
 def _get_page_size() -> int:
     page_size = request.args.get("per_page", type=int, default=DEFAULT_PAGE_SIZE)
     return max(1, min(page_size, MAX_PAGE_SIZE))
+
+
+def _format_hospital_label(hospital: Hospital) -> str:
+    locality = getattr(hospital, "localidad", None) or getattr(hospital, "direccion", None)
+    return f"{hospital.nombre} - {locality}" if locality else hospital.nombre
+
+
+def _paginate(query, page: int, per_page: int):
+    offset = max(page - 1, 0) * per_page
+    items = query.limit(per_page + 1).offset(offset).all()
+    has_next = len(items) > per_page
+    if has_next:
+        items = items[:-1]
+    return items, has_next
+
+
+@api_bp.route("/search/hospitales")
+@login_required
+def search_hospitales():
+    query_value = _sanitize_query_param()
+    page = request.args.get("page", type=int, default=1)
+
+    lookup = Hospital.query.order_by(asc(Hospital.nombre))
+    if query_value and query_value != "...":
+        like = f"%{query_value}%"
+        conditions = [Hospital.nombre.ilike(like)]
+        localidad_column = getattr(Hospital, "localidad", None)
+        if localidad_column is not None:
+            conditions.append(localidad_column.ilike(like))
+        direccion_column = getattr(Hospital, "direccion", None)
+        if direccion_column is not None and direccion_column not in conditions:
+            conditions.append(direccion_column.ilike(like))
+        lookup = lookup.filter(or_(*conditions))
+    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
+    results = [
+        {
+            "id": hospital.id,
+            "text": _format_hospital_label(hospital),
+        }
+        for hospital in items
+    ]
+    return jsonify({"results": results, "next": has_next})
+
+
+@api_bp.route("/search/servicios")
+@login_required
+def search_servicios_lookup():
+    hospital_id = request.args.get("hospital_id", type=int)
+    if not hospital_id:
+        return (
+            jsonify({"results": [], "next": False, "message": "Seleccione un hospital"}),
+            400,
+        )
+
+    query_value = _sanitize_query_param()
+    page = request.args.get("page", type=int, default=1)
+
+    lookup = Servicio.query.filter(Servicio.hospital_id == hospital_id).order_by(asc(Servicio.nombre))
+    if query_value and query_value != "...":
+        like = f"%{query_value}%"
+        lookup = lookup.filter(Servicio.nombre.ilike(like))
+
+    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
+    results = [
+        {
+            "id": servicio.id,
+            "text": servicio.nombre,
+        }
+        for servicio in items
+    ]
+    return jsonify({"results": results, "next": has_next})
+
+
+@api_bp.route("/search/oficinas")
+@login_required
+def search_oficinas_lookup():
+    hospital_id = request.args.get("hospital_id", type=int)
+    if not hospital_id:
+        return (
+            jsonify({"results": [], "next": False, "message": "Seleccione un hospital"}),
+            400,
+        )
+    servicio_id = request.args.get("servicio_id", type=int)
+
+    query_value = _sanitize_query_param()
+    page = request.args.get("page", type=int, default=1)
+
+    lookup = Oficina.query.filter(Oficina.hospital_id == hospital_id).order_by(asc(Oficina.nombre))
+    if servicio_id:
+        lookup = lookup.filter(Oficina.servicio_id == servicio_id)
+    if query_value and query_value != "...":
+        like = f"%{query_value}%"
+        lookup = lookup.filter(Oficina.nombre.ilike(like))
+
+    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
+    results = [
+        {
+            "id": oficina.id,
+            "text": oficina.nombre,
+        }
+        for oficina in items
+    ]
+    return jsonify({"results": results, "next": has_next})
 
 
 @api_bp.route("/servicios/search")

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     "audit_service",
     "licencia_service",
     "insumo_service",
+    "equipo_service",
 ]

--- a/app/services/equipo_service.py
+++ b/app/services/equipo_service.py
@@ -1,0 +1,34 @@
+"""Utility helpers for equipment domain logic."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models import Equipo
+
+
+def generate_internal_serial(session: Session, year: int | None = None) -> str:
+    """Return a unique serial number for equipment without visible serial."""
+
+    year = year or datetime.utcnow().year
+    prefix = f"SNV-{year:04d}"
+    like_expression = f"{prefix}-%"
+    last_value = (
+        session.query(Equipo.numero_serie)
+        .filter(Equipo.numero_serie.ilike(like_expression))
+        .order_by(Equipo.numero_serie.desc())
+        .first()
+    )
+    next_sequence = 1
+    if last_value and last_value[0]:
+        try:
+            last_sequence = int(str(last_value[0]).split("-")[-1])
+        except (ValueError, IndexError):
+            next_sequence = 1
+        else:
+            next_sequence = last_sequence + 1
+    return f"{prefix}-{next_sequence:06d}"
+
+
+__all__ = ["generate_internal_serial"]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -146,3 +146,32 @@ body {
   padding: 1rem;
   color: #6c757d;
 }
+
+.lookup-control {
+  position: relative;
+}
+
+.lookup-control .input-group > input {
+  min-width: 0;
+}
+
+.lookup-control .lookup-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1020;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: none;
+  box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.08);
+}
+
+.lookup-control .lookup-results .list-group-item {
+  cursor: pointer;
+}
+
+.object-fit-cover {
+  object-fit: cover;
+}

--- a/app/static/js/lookups.js
+++ b/app/static/js/lookups.js
@@ -1,0 +1,273 @@
+(function () {
+  const registry = new Map();
+
+  function debounce(fn, delay = 300) {
+    let timeoutId;
+    return function (...args) {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn.apply(this, args), delay);
+    };
+  }
+
+  function parseJsonAttribute(value, fallback) {
+    if (!value) {
+      return fallback;
+    }
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      console.warn('No se pudo parsear el atributo de búsqueda', error);
+      return fallback;
+    }
+  }
+
+  class LookupControl {
+    constructor(input) {
+      this.input = input;
+      this.hidden = document.getElementById(input.dataset.lookupHidden || '');
+      this.container = input.closest('.lookup-control');
+      this.results = this.container ? this.container.querySelector('[data-lookup-results]') : null;
+      this.clearButton = this.container ? this.container.querySelector('[data-lookup-clear]') : null;
+      this.showAllButton = this.container ? this.container.querySelector('[data-lookup-show-all]') : null;
+      this.params = parseJsonAttribute(input.dataset.lookupParams, {});
+      this.requiredParams = new Set(parseJsonAttribute(input.dataset.lookupRequired, []));
+      this.resetTargets = parseJsonAttribute(input.dataset.lookupReset, []);
+      this.requiredMessage = input.dataset.lookupRequiredMessage || null;
+      this.page = 1;
+      this.currentQuery = '';
+      this.loading = false;
+      this.nextPage = null;
+      this.debouncedSearch = debounce((value) => this.search(value), 300);
+
+      registry.set(this.input.id, this);
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.input.addEventListener('input', () => {
+        const value = this.input.value.trim();
+        if (!value) {
+          this.reset();
+          return;
+        }
+        this.hidden && (this.hidden.value = '');
+        this.debouncedSearch(value);
+      });
+
+      this.input.addEventListener('focus', () => {
+        if (this.results && this.results.children.length) {
+          this.results.classList.remove('d-none');
+        }
+      });
+
+      this.clearButton &&
+        this.clearButton.addEventListener('click', () => {
+          this.reset();
+        });
+
+      this.showAllButton &&
+        this.showAllButton.addEventListener('click', () => {
+          this.input.value = '...';
+          this.search('...');
+        });
+
+      document.addEventListener('click', (event) => {
+        if (!this.container || this.container.contains(event.target)) {
+          return;
+        }
+        this.hideResults();
+      });
+
+      if (this.results) {
+        this.results.addEventListener('click', (event) => {
+          const button = event.target.closest('[data-value]');
+          if (!button) {
+            if (event.target.matches('[data-load-more]')) {
+              this.loadMore();
+            }
+            return;
+          }
+          this.selectOption({ id: button.dataset.value, text: button.dataset.text || button.textContent.trim() });
+        });
+      }
+    }
+
+    buildParams() {
+      const params = {};
+      for (const [param, elementId] of Object.entries(this.params)) {
+        if (!elementId) {
+          continue;
+        }
+        const element = document.getElementById(elementId);
+        const value = element ? element.value : '';
+        if (!value && this.requiredParams.has(param)) {
+          return { ok: false, message: this.requiredMessage || 'Complete los datos requeridos.' };
+        }
+        if (value) {
+          params[param] = value;
+        }
+      }
+      return { ok: true, params };
+    }
+
+    async search(query, page = 1, append = false) {
+      if (this.loading) {
+        return;
+      }
+      const { ok, params, message } = this.buildParams();
+      if (!ok) {
+        this.showMessage(message || 'Seleccione una opción previa.');
+        return;
+      }
+
+      const url = new URL(this.input.dataset.lookupUrl, window.location.origin);
+      url.searchParams.set('q', query);
+      url.searchParams.set('page', page);
+      Object.entries(params || {}).forEach(([key, value]) => {
+        url.searchParams.set(key, value);
+      });
+
+      this.loading = true;
+      this.showMessage('Buscando…', append);
+
+      try {
+        const response = await fetch(url, { credentials: 'include' });
+        const data = await response.json();
+        if (!response.ok) {
+          const errorMessage = data && data.message ? data.message : 'Sin resultados disponibles.';
+          this.showMessage(errorMessage);
+          return;
+        }
+        this.currentQuery = query;
+        this.page = page;
+        this.nextPage = data.next ? page + 1 : null;
+        this.renderResults(data.results || [], append);
+      } catch (error) {
+        console.error('Error al buscar opciones', error);
+        this.showMessage('No se pudo obtener la información.');
+      } finally {
+        this.loading = false;
+      }
+    }
+
+    loadMore() {
+      if (!this.nextPage) {
+        return;
+      }
+      this.search(this.currentQuery, this.nextPage, true);
+    }
+
+    renderResults(items, append) {
+      if (!this.results) {
+        return;
+      }
+      if (!append) {
+        this.results.innerHTML = '';
+      } else {
+        const loadMoreButton = this.results.querySelector('[data-load-more]');
+        loadMoreButton && loadMoreButton.remove();
+      }
+
+      if (!items.length && !append) {
+        this.showMessage('Sin resultados coincidentes.');
+        return;
+      }
+
+      items.forEach((item) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'list-group-item list-group-item-action';
+        button.dataset.value = item.id;
+        button.dataset.text = item.text;
+        button.textContent = item.text;
+        this.results.appendChild(button);
+      });
+
+      if (this.nextPage) {
+        const loadMore = document.createElement('button');
+        loadMore.type = 'button';
+        loadMore.className = 'list-group-item list-group-item-action text-center text-primary fw-semibold';
+        loadMore.dataset.loadMore = 'true';
+        loadMore.textContent = 'Cargar más';
+        this.results.appendChild(loadMore);
+      }
+
+      this.results.classList.remove('d-none');
+    }
+
+    showMessage(message, append = false) {
+      if (!this.results) {
+        return;
+      }
+      if (!append) {
+        this.results.innerHTML = '';
+      }
+      const info = document.createElement('div');
+      info.className = 'list-group-item text-muted small';
+      info.textContent = message;
+      this.results.appendChild(info);
+      this.results.classList.remove('d-none');
+    }
+
+    hideResults(clear = false) {
+      if (!this.results) {
+        return;
+      }
+      if (clear) {
+        this.results.innerHTML = '';
+      }
+      this.results.classList.add('d-none');
+    }
+
+    selectOption(item) {
+      this.input.value = item.text;
+      if (this.hidden) {
+        this.hidden.value = item.id;
+      }
+      this.hideResults(true);
+      this.resetDependents();
+    }
+
+    reset({ notify = true } = {}) {
+      this.input.value = '';
+      if (this.hidden) {
+        this.hidden.value = '';
+      }
+      this.currentQuery = '';
+      this.page = 1;
+      this.nextPage = null;
+      this.hideResults(true);
+      if (notify) {
+        this.resetDependents();
+      }
+    }
+
+    resetDependents() {
+      this.resetTargets.forEach((targetId) => {
+        const lookup = registry.get(targetId);
+        if (lookup) {
+          lookup.reset();
+          return;
+        }
+        const element = document.getElementById(targetId);
+        if (element) {
+          element.value = '';
+        }
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-lookup="true"]').forEach((input) => {
+      if (!input.id) {
+        console.warn('El campo de búsqueda debe tener un id único.');
+        return;
+      }
+      if (!input.dataset.lookupUrl) {
+        console.warn('Falta data-lookup-url en el campo', input);
+        return;
+      }
+      new LookupControl(input);
+    });
+  });
+})();

--- a/app/templates/_form_helpers.html
+++ b/app/templates/_form_helpers.html
@@ -23,6 +23,52 @@
   {{ render_field(field, form_group_class=form_group_class, label_class=label_class, input_class=select_class|trim, extra_attrs=attrs) }}
 {%- endmacro %}
 
+{% macro render_lookup(field, hidden_field, endpoint, form_group_class='mb-3', label_class='form-label', placeholder='', params=None, required_params=None, reset_targets=None, requires_message=None, extra_attrs=None) -%}
+  {% set attrs = {
+    'class': 'form-control' ~ (' is-invalid' if field.errors else ''),
+    'autocomplete': 'off',
+    'placeholder': placeholder,
+    'data-lookup': 'true',
+    'data-lookup-url': endpoint,
+    'data-lookup-hidden': hidden_field.id,
+  } %}
+  {% if params %}
+    {% set attrs = attrs | combine({'data-lookup-params': params|tojson}) %}
+  {% endif %}
+  {% if required_params %}
+    {% set attrs = attrs | combine({'data-lookup-required': required_params|tojson}) %}
+  {% endif %}
+  {% if reset_targets %}
+    {% set attrs = attrs | combine({'data-lookup-reset': reset_targets|tojson}) %}
+  {% endif %}
+  {% if requires_message %}
+    {% set attrs = attrs | combine({'data-lookup-required-message': requires_message}) %}
+  {% endif %}
+  {% if extra_attrs %}
+    {% set attrs = attrs | combine(extra_attrs) %}
+  {% endif %}
+  <div class="{{ form_group_class }}">
+    {{ field.label(class=label_class, for=field.id) }}
+    <div class="lookup-control">
+      <div class="input-group">
+        <input type="text" id="{{ field.id }}" name="{{ field.name }}" value="{{ field.data or '' }}"{% for key, value in attrs.items() if value is not none %} {{ key }}="{{ value|safe if 'data-' in key else value }}"{% endfor %}>
+        <button class="btn btn-outline-secondary" type="button" title="Mostrar todo" data-lookup-show-all>…</button>
+        <button class="btn btn-outline-secondary" type="button" title="Limpiar" data-lookup-clear>&times;</button>
+      </div>
+      {{ hidden_field() }}
+      <div class="lookup-results list-group d-none" data-lookup-results role="listbox" aria-label="Opciones para {{ field.label.text }}"></div>
+    </div>
+    {% if field.description %}
+      <div class="form-text">{{ field.description }}</div>
+    {% endif %}
+    {% if field.errors %}
+      {% for error in field.errors %}
+        <div class="invalid-feedback d-block">{{ error }}</div>
+      {% endfor %}
+    {% endif %}
+  </div>
+{%- endmacro %}
+
 {% macro render_ajax_select(field, endpoint, form_group_class='mb-3', label_class='form-label', placeholder='Escriba para buscar…', input_class='form-select', multiple=None, depends_on=None, depends_message=None, min_chars=1, extra_attrs=None, class_='') -%}
   {% set attrs = {
     'data-control': 'tom-select',

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -83,6 +83,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
     <script src="{{ url_for('static', filename='js/layout.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/lookups.js') }}"></script>
     <script src="{{ url_for('static', filename='js/forms/autocomplete.js') }}"></script>
     {% block scripts %}{% endblock %}
   </body>

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -100,6 +100,55 @@
     </div>
   </div>
 </div>
+<div class="card mt-3">
+  <div class="card-header d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-2">
+    <div>
+      <h2 class="h6 mb-0">Evidencias del equipo</h2>
+      <p class="mb-0 text-muted small">Adjunte imágenes o PDF relacionados al equipo.</p>
+    </div>
+    <form method="post" enctype="multipart/form-data" class="d-flex flex-wrap gap-2" action="{{ url_for('equipos.subir_adjunto', equipo_id=equipo.id) }}">
+      {{ adjunto_form.hidden_tag() }}
+      <div>
+        {{ adjunto_form.archivo(class='form-control form-control-sm') }}
+      </div>
+      <button class="btn btn-sm btn-primary" type="submit">Subir</button>
+    </form>
+  </div>
+  <div class="card-body">
+    <div class="row g-3">
+      {% for archivo in archivos %}
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card h-100 shadow-sm">
+          {% if archivo.mime_type.startswith('image/') %}
+          <div class="ratio ratio-4x3">
+            <img src="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" alt="{{ archivo.filename }}" class="w-100 h-100 object-fit-cover rounded-top">
+          </div>
+          {% else %}
+          <div class="d-flex align-items-center justify-content-center py-4 bg-light border-bottom">
+            <span class="fw-semibold text-secondary">PDF</span>
+          </div>
+          {% endif %}
+          <div class="card-body d-flex flex-column gap-2">
+            <div class="small" title="{{ archivo.filename }}">{{ archivo.filename }}</div>
+            <div class="d-flex flex-wrap gap-2">
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}">Descargar</a>
+              <form method="post" action="{{ url_for('equipos.eliminar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}" onsubmit="return confirm('¿Eliminar adjunto?');">
+                {{ csrf_token() }}
+                <button class="btn btn-sm btn-outline-danger" type="submit">Eliminar</button>
+              </form>
+            </div>
+            <small class="text-muted">Subido {{ archivo.created_at.strftime('%d/%m/%Y %H:%M') if archivo.created_at else '' }}</small>
+          </div>
+        </div>
+      </div>
+      {% else %}
+      <div class="col-12">
+        <div class="alert alert-light border mb-0">No hay adjuntos cargados.</div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
 <div class="row g-3 mt-3">
   <div class="col-md-6">
     <div class="card h-100">

--- a/app/templates/equipos/formulario.html
+++ b/app/templates/equipos/formulario.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_form_helpers.html' import render_field, render_select, render_textarea, render_ajax_select %}
+{% from '_form_helpers.html' import render_field, render_select, render_textarea, render_lookup, render_checkbox %}
 {% block title %}{{ titulo }}{% endblock %}
 {% block header_title %}{{ titulo }}{% endblock %}
 {% block content %}
@@ -11,21 +11,37 @@
       {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3, placeholder='Descripción breve del equipo') }}
       {{ render_select(form.tipo, form_group_class='col-12 col-md-6', label_class='form-label') }}
       {{ render_select(form.estado, form_group_class='col-12 col-md-6', label_class='form-label') }}
-      {{ render_select(form.hospital_id, form_group_class='col-12 col-md-6', label_class='form-label') }}
-      {{ render_ajax_select(
-        form.servicio_id,
-        url_for('api.search_servicios'),
+      {{ render_lookup(
+        form.hospital_busqueda,
+        form.hospital_id,
+        url_for('api.search_hospitales'),
         form_group_class='col-12 col-md-6',
-        placeholder='Escriba para buscar un servicio',
-        extra_attrs={'data-min-chars': 1}
+        placeholder='Buscar hospital',
+        reset_targets=[
+          form.servicio_busqueda.id,
+          form.oficina_busqueda.id
+        ]
       ) }}
-      {{ render_ajax_select(
-        form.oficina_id,
-        url_for('api.search_oficinas'),
+      {{ render_lookup(
+        form.servicio_busqueda,
+        form.servicio_id,
+        url_for('api.search_servicios_lookup'),
         form_group_class='col-12 col-md-6',
-        placeholder='Filtre oficinas por servicio',
-        depends_on=form.servicio_id.id,
-        depends_message='Seleccione un servicio para filtrar oficinas'
+        placeholder='Buscar servicio',
+        params={'hospital_id': form.hospital_id.id},
+        required_params=['hospital_id'],
+        reset_targets=[form.oficina_busqueda.id],
+        requires_message='Seleccione un hospital para buscar servicios'
+      ) }}
+      {{ render_lookup(
+        form.oficina_busqueda,
+        form.oficina_id,
+        url_for('api.search_oficinas_lookup'),
+        form_group_class='col-12 col-md-6',
+        placeholder='Buscar oficina',
+        params={'hospital_id': form.hospital_id.id, 'servicio_id': form.servicio_id.id},
+        required_params=['hospital_id'],
+        requires_message='Seleccione un hospital para buscar oficinas'
       ) }}
       {{ render_field(form.responsable, form_group_class='col-12 col-md-6', placeholder='Responsable del equipo') }}
     </div>
@@ -36,6 +52,7 @@
       {{ render_field(form.marca, form_group_class='col-12 col-md-4', placeholder='Marca') }}
       {{ render_field(form.modelo, form_group_class='col-12 col-md-4', placeholder='Modelo') }}
       {{ render_field(form.numero_serie, form_group_class='col-12 col-md-4', placeholder='Número de serie') }}
+      {{ render_checkbox(form.sin_numero_serie, form_group_class='col-12 col-md-4 align-self-end') }}
       {{ render_field(form.fecha_compra, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='date') }}
@@ -46,40 +63,6 @@
     <div class="section-body row g-3">
       {{ render_field(form.codigo, form_group_class='col-12 col-md-6', placeholder='Código patrimonial') }}
       {{ render_textarea(form.observaciones, form_group_class='col-12', rows=3, placeholder='Observaciones relevantes') }}
-    </div>
-  </div>
-  <div class="form-section">
-    <div class="section-header">Insumos asociados</div>
-    <div class="section-body row g-3">
-      <div class="col-12">
-        {{ render_ajax_select(
-          form.insumos,
-          url_for('api.search_insumos'),
-          form_group_class='mb-3',
-          placeholder='Escriba para buscar insumos',
-          multiple=true,
-          extra_attrs={'data-role': 'insumos-selector'}
-        ) }}
-      </div>
-      <div class="col-12">
-        <div class="form-section mb-0 d-none" data-insumos-card>
-          <div class="section-header">Cantidades por insumo (próximamente)</div>
-          <div class="section-body">
-            <div class="table-responsive">
-              <table class="table table-sm align-middle">
-                <thead>
-                  <tr>
-                    <th>Insumo</th>
-                    <th style="width: 140px;">Cantidad</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-              <div class="insumo-table-placeholder text-muted small">Las cantidades se preparan para futuras versiones.</div>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div class="d-flex flex-column flex-md-row gap-2 justify-content-end">

--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ class Config:
     UPLOAD_FOLDER: str = os.getenv("UPLOAD_FOLDER", _default_upload_dir())
     ADJUNTOS_SUBFOLDER: str = os.getenv("ADJUNTOS_SUBFOLDER", "adjuntos")
     DOCSCAN_SUBFOLDER: str = os.getenv("DOCSCAN_SUBFOLDER", "docscan")
+    EQUIPOS_SUBFOLDER: str = os.getenv("EQUIPOS_SUBFOLDER", "equipos")
     MAX_CONTENT_LENGTH: int = int(os.getenv("MAX_CONTENT_LENGTH", 16 * 1024 * 1024))
     ALLOWED_EXTENSIONS: set[str] = set(
         os.getenv("ALLOWED_EXTENSIONS", "pdf,jpg,jpeg,png").split(",")

--- a/migrations/versions/bd8b7d50f9ac_add_equipo_adjuntos_and_serial_flag.py
+++ b/migrations/versions/bd8b7d50f9ac_add_equipo_adjuntos_and_serial_flag.py
@@ -1,0 +1,41 @@
+"""add equipo adjuntos table and serial flag"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "bd8b7d50f9ac"
+down_revision = "8a9f4ce0f1a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "equipos",
+        sa.Column("sin_numero_serie", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.create_table(
+        "equipos_adjuntos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("filepath", sa.String(length=255), nullable=False),
+        sa.Column("mime_type", sa.String(length=120), nullable=False),
+        sa.Column("uploaded_by_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_equipos_adjuntos_equipo_id", "equipos_adjuntos", ["equipo_id"])
+    op.alter_column("equipos", "sin_numero_serie", server_default=None)
+
+
+def downgrade():
+    op.drop_index("ix_equipos_adjuntos_equipo_id", table_name="equipos_adjuntos")
+    op.drop_table("equipos_adjuntos")
+    op.drop_column("equipos", "sin_numero_serie")

--- a/tests/test_equipos.py
+++ b/tests/test_equipos.py
@@ -1,0 +1,91 @@
+from io import BytesIO
+from pathlib import Path
+
+from app.models import Equipo, EquipoAdjunto, EstadoEquipo, TipoEquipo
+
+
+def login(client, username: str, password: str) -> None:
+    client.post(
+        "/auth/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+
+
+def _base_equipo_form(hospital, include_serial: bool = True) -> dict[str, str]:
+    data = {
+        "descripcion": "Router de prueba",
+        "tipo": TipoEquipo.ROUTER.value,
+        "estado": EstadoEquipo.OPERATIVO.value,
+        "hospital_busqueda": hospital.nombre,
+        "hospital_id": str(hospital.id),
+        "servicio_busqueda": "",
+        "servicio_id": "",
+        "oficina_busqueda": "",
+        "oficina_id": "",
+        "numero_serie": "SN-12345" if include_serial else "",
+    }
+    return data
+
+
+def test_equipo_requires_serial_when_flag_not_checked(client, admin_credentials, data):
+    login(client, **admin_credentials)
+    form_data = _base_equipo_form(data["hospital"], include_serial=False)
+    response = client.post("/equipos/crear", data=form_data, follow_redirects=True)
+    assert response.status_code == 200
+    assert "Ingrese un número de serie" in response.get_data(as_text=True)
+
+
+def test_equipo_generates_internal_serial(client, admin_credentials, data):
+    login(client, **admin_credentials)
+    form_data = _base_equipo_form(data["hospital"], include_serial=False)
+    form_data["sin_numero_serie"] = "y"
+    response = client.post("/equipos/crear", data=form_data, follow_redirects=False)
+    assert response.status_code == 302
+    nuevo = Equipo.query.order_by(Equipo.id.desc()).first()
+    assert nuevo is not None
+    assert nuevo.sin_numero_serie is True
+    assert nuevo.numero_serie and nuevo.numero_serie.startswith("SNV-")
+
+
+def test_equipo_requires_valid_hospital_lookup(client, admin_credentials, data):
+    login(client, **admin_credentials)
+    form_data = _base_equipo_form(data["hospital"], include_serial=True)
+    form_data["hospital_id"] = ""
+    response = client.post("/equipos/crear", data=form_data, follow_redirects=True)
+    assert response.status_code == 200
+    assert "Seleccione una opción válida" in response.get_data(as_text=True)
+
+
+def test_equipo_adjuntos_upload_download_and_delete(client, admin_credentials, data):
+    login(client, **admin_credentials)
+    equipo = data["equipo"]
+    upload_data = {
+        "archivo": (BytesIO(b"fake image data"), "foto.jpg"),
+    }
+    response = client.post(
+        f"/equipos/{equipo.id}/adjuntos/subir",
+        data=upload_data,
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    adjunto = EquipoAdjunto.query.filter_by(equipo_id=equipo.id).order_by(EquipoAdjunto.id.desc()).first()
+    assert adjunto is not None
+    stored_path = Path(adjunto.filepath)
+    assert stored_path.exists()
+
+    preview = client.get(
+        f"/equipos/{equipo.id}/adjuntos/{adjunto.id}/descargar?preview=1",
+        follow_redirects=False,
+    )
+    assert preview.status_code == 200
+    assert preview.mimetype.startswith("image/")
+
+    delete_resp = client.post(
+        f"/equipos/{equipo.id}/adjuntos/{adjunto.id}/eliminar",
+        follow_redirects=False,
+    )
+    assert delete_resp.status_code == 302
+    assert not stored_path.exists()
+    assert EquipoAdjunto.query.get(adjunto.id) is None


### PR DESCRIPTION
## Resumen
- reemplazar los selects de Hospital/Servicio/Oficina por campos con búsqueda asincrónica y validaciones en el servidor
- aplicar la nueva regla para número de serie con casilla "Sin número de serie visible" y generación automática SNV-YYYY-XXXXXX
- permitir adjuntar y gestionar evidencias (imágenes/PDF) de equipos, incluyendo nuevo modelo, API y UI responsive

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3c0f6cbe883248a8490a3c1bce262