### PR TITLE
Improve equipment UX, dependent search, and attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Generated at runtime to avoid committing binary assets
+app/static/favicon.ico
+
+# Bytecode caches
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ python seeds/seed.py
 
 # Ejecutar
 flask run                          # o python wsgi.py
+
+# Exponer en red local (LAN)
+export FLASK_RUN_HOST=0.0.0.0      # acceder vía http://<ip_local>:5000/
 ```
 
 ### 5.3 Con Docker
@@ -189,6 +192,8 @@ flask db upgrade
 ```
 
 El repositorio incluye una migración inicial con todas las tablas declaradas en `app/models`. El comando `flask db upgrade` tomará la URL configurada en `DATABASE_URL` (o el valor por defecto de `config.py`).
+
+La migración `c6be45c2d4ab_equipos_lookup_updates` añade el tamaño de archivo a `equipos_adjuntos` y crea índices de búsqueda sobre hospitales/servicios/oficinas. Se implementa con `op.batch_alter_table(..., recreate="always")` para mantener la compatibilidad con SQLite durante pruebas locales.
 
 Seeds (`seeds/seed.py`): abre una sesión SQLAlchemy sobre `DATABASE_URL`, limpia los datos existentes y vuelve a poblar la base con hospitales (Lucio Molas, René Favaloro), usuarios base, permisos por módulo/hospital, inventario de ejemplo (equipos + insumos) y licencias en distintos estados:
 
@@ -300,6 +305,14 @@ Casos clave:
 - Licencias (solapamientos, estados, bloqueos operativos, reemplazos).
 - Generación de actas PDF (smoke test de servicio).
 - Auditoría.
+
+### 12.1 Pruebas manuales sugeridas
+
+1. Crear/editar un equipo verificando que los selectores Hospital → Servicio → Oficina respeten la dependencia y permitan buscar toda la base desde el botón “…” (enviar `q=...`).
+2. Marcar “Sin N° de serie visible” y confirmar que el sistema deshabilita el campo y genera un código interno `EQ-AAAAMMDD-####` al guardar.
+3. Subir y eliminar evidencias (PNG/JPG/PDF) verificando tamaño máximo, vista previa y confirmando que la eliminación solicita CSRF y registra evento en el historial.
+4. Revisar el detalle del equipo: los bloques “Historial reciente” y “Actas vinculadas” deben mostrar hasta tres ítems y ofrecer el enlace “Ver todo” para abrir la vista completa con filtros.
+5. Actualizar datos personales desde “Mi perfil” y confirmar que el dropdown superior muestra el acceso rápido junto con la opción para cerrar sesión.
 
 ## 13. Uso con GitHub y Codex (desarrollo por partes)
 

--- a/app/assets/__init__.py
+++ b/app/assets/__init__.py
@@ -1,0 +1,24 @@
+"""Static asset helpers for the Inventario Hospital application."""
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["ensure_favicon", "ensure_static_asset"]
+
+
+def ensure_static_asset(target: Path, data: bytes) -> Path:
+    """Write ``data`` to ``target`` if the file does not yet exist.
+
+    The helper guarantees idempotency and creates any missing parent
+    directories so assets can be materialised lazily during application
+    start-up.  The resulting path is returned so callers can easily use it
+    for logging or additional processing.
+    """
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not target.exists():
+        target.write_bytes(data)
+    return target
+
+
+from .favicon import ensure_favicon  # noqa: E402  (import after helper definition)

--- a/app/assets/favicon.py
+++ b/app/assets/favicon.py
@@ -1,0 +1,52 @@
+"""Favicon generation helpers."""
+from __future__ import annotations
+
+from base64 import b64decode
+from pathlib import Path
+
+from . import ensure_static_asset
+
+# Embedded 16x16 favicon (ICO) encoded in base64 so we can avoid committing a
+# binary blob to the repository while still serving a proper ``favicon.ico``.
+_FAVICON_B64 = (
+    "AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAA"
+    "AAAAAAAAAAAAAAAAAAD9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3//W4N//1u"
+    "Df/9bg3//W4N//1uDf/9bg3//W4N//1uDf/9bg3/AAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+)
+
+
+def ensure_favicon(static_folder: str | Path) -> Path:
+    """Make sure ``favicon.ico`` exists under ``static_folder``.
+
+    The helper can be called multiple times without rewriting the file and
+    returns the resulting :class:`~pathlib.Path` for convenience.
+    """
+
+    static_path = Path(static_folder)
+    target = static_path / "favicon.ico"
+    data = b64decode(_FAVICON_B64)
+    return ensure_static_asset(target, data)
+
+
+__all__ = ["ensure_favicon"]

--- a/app/forms/equipo.py
+++ b/app/forms/equipo.py
@@ -16,7 +16,14 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, Length, Optional
 
-from app.models import EstadoEquipo, Hospital, Oficina, Servicio, TipoEquipo
+from app.models import (
+    EstadoEquipo,
+    Hospital,
+    Oficina,
+    Servicio,
+    TipoActa,
+    TipoEquipo,
+)
 
 
 class EquipoForm(FlaskForm):
@@ -191,4 +198,65 @@ class EquipoAdjuntoForm(FlaskForm):
     submit = SubmitField("Subir archivo")
 
 
-__all__ = ["EquipoForm", "EquipoFiltroForm", "EquipoAdjuntoForm"]
+class EquipoAdjuntoDeleteForm(FlaskForm):
+    """Simple CSRF protected form to remove an attachment."""
+
+    submit = SubmitField("Eliminar")
+
+
+class EquipoHistorialFiltroForm(FlaskForm):
+    """Filter historical entries for an equipment."""
+
+    accion = StringField("Acción", validators=[Optional(), Length(max=120)])
+    fecha_desde = DateField("Desde", validators=[Optional()])
+    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    submit = SubmitField("Filtrar")
+
+    def validate(self, extra_validators=None):  # type: ignore[override]
+        if not super().validate(extra_validators=extra_validators):
+            return False
+        if (
+            self.fecha_desde.data
+            and self.fecha_hasta.data
+            and self.fecha_desde.data > self.fecha_hasta.data
+        ):
+            self.fecha_hasta.errors.append("La fecha hasta debe ser posterior a la fecha desde")
+            return False
+        return True
+
+
+class EquipoActaFiltroForm(FlaskForm):
+    """Filter actas associated with an equipment."""
+
+    tipo = SelectField("Tipo", coerce=str, validators=[Optional()])
+    fecha_desde = DateField("Desde", validators=[Optional()])
+    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    submit = SubmitField("Filtrar")
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.tipo.choices = [("", "Todos")] + [
+            (tipo.value, tipo.name.replace("_", " ").title()) for tipo in TipoActa
+        ]
+
+    def validate(self, extra_validators=None):  # type: ignore[override]
+        if not super().validate(extra_validators=extra_validators):
+            return False
+        if (
+            self.fecha_desde.data
+            and self.fecha_hasta.data
+            and self.fecha_desde.data > self.fecha_hasta.data
+        ):
+            self.fecha_hasta.errors.append("La fecha hasta debe ser posterior a la fecha desde")
+            return False
+        return True
+
+
+__all__ = [
+    "EquipoForm",
+    "EquipoFiltroForm",
+    "EquipoAdjuntoForm",
+    "EquipoAdjuntoDeleteForm",
+    "EquipoHistorialFiltroForm",
+    "EquipoActaFiltroForm",
+]

--- a/app/forms/usuario.py
+++ b/app/forms/usuario.py
@@ -56,4 +56,29 @@ class UsuarioForm(FlaskForm):
         return True
 
 
-__all__ = ["UsuarioForm"]
+class PerfilForm(FlaskForm):
+    """Allow an authenticated user to update their own profile."""
+
+    nombre = StringField("Nombre", validators=[DataRequired(), Length(max=120)])
+    apellido = StringField("Apellido", validators=[Optional(), Length(max=120)])
+    email = StringField("Email", validators=[DataRequired(), Email(), Length(max=255)])
+    telefono = StringField("Teléfono", validators=[Optional(), Length(max=50)])
+    password = PasswordField("Nueva contraseña", validators=[Optional(), Length(min=8, max=128)])
+    confirm_password = PasswordField(
+        "Confirmar contraseña",
+        validators=[Optional(), EqualTo("password", message="Las contraseñas deben coincidir.")],
+    )
+    submit = SubmitField("Guardar cambios")
+
+    def __init__(self, usuario: Usuario, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._usuario = usuario
+
+    def validate_email(self, field):  # type: ignore[override]
+        query = Usuario.query.filter(Usuario.email == field.data)
+        query = query.filter(Usuario.id != self._usuario.id)
+        if query.first():
+            raise ValidationError("Ya existe un usuario con este email")
+
+
+__all__ = ["UsuarioForm", "PerfilForm"]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,7 +6,7 @@ from .adjunto import Adjunto, TipoAdjunto
 from .auditoria import Auditoria
 from .base import Base
 from .docscan import Docscan, TipoDocscan
-from .equipo import Equipo, EstadoEquipo, TipoEquipo
+from .equipo import Equipo, EquipoHistorial, EstadoEquipo, TipoEquipo
 from .equipo_adjunto import EquipoAdjunto
 from .hospital import Hospital, Oficina, Servicio
 from .insumo import Insumo, InsumoMovimiento, MovimientoTipo, equipo_insumos
@@ -26,6 +26,7 @@ __all__ = [
     "Docscan",
     "TipoDocscan",
     "Equipo",
+    "EquipoHistorial",
     "EstadoEquipo",
     "TipoEquipo",
     "EquipoAdjunto",

--- a/app/models/equipo_adjunto.py
+++ b/app/models/equipo_adjunto.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -25,12 +25,18 @@ class EquipoAdjunto(Base):
     filepath: Mapped[str] = mapped_column(String(255), nullable=False)
     mime_type: Mapped[str] = mapped_column(String(120), nullable=False)
     uploaded_by_id: Mapped[int | None] = mapped_column(ForeignKey("usuarios.id"))
+    file_size: Mapped[int | None] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
     )
 
     equipo: Mapped["Equipo"] = relationship("Equipo", back_populates="archivos")
     uploaded_by: Mapped["Usuario | None"] = relationship("Usuario")
+
+    def size_in_bytes(self) -> int | None:
+        """Return the stored file size, if available."""
+
+        return self.file_size
 
 
 __all__ = ["EquipoAdjunto"]

--- a/app/models/hospital.py
+++ b/app/models/hospital.py
@@ -24,7 +24,7 @@ class Hospital(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     nombre: Mapped[str] = mapped_column(String(120), nullable=False, unique=True)
     codigo: Mapped[str | None] = mapped_column(String(20), unique=True)
-    direccion: Mapped[str | None] = mapped_column(String(255))
+    direccion: Mapped[str | None] = mapped_column(String(255), index=True)
     telefono: Mapped[str | None] = mapped_column(String(50))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
@@ -60,7 +60,7 @@ class Servicio(Base):
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    nombre: Mapped[str] = mapped_column(String(120), nullable=False)
+    nombre: Mapped[str] = mapped_column(String(120), nullable=False, index=True)
     descripcion: Mapped[str | None] = mapped_column(String(255))
     hospital_id: Mapped[int] = mapped_column(ForeignKey("hospitales.id"), nullable=False)
 
@@ -82,7 +82,7 @@ class Oficina(Base):
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    nombre: Mapped[str] = mapped_column(String(120), nullable=False)
+    nombre: Mapped[str] = mapped_column(String(120), nullable=False, index=True)
     piso: Mapped[str | None] = mapped_column(String(20))
     servicio_id: Mapped[int] = mapped_column(ForeignKey("servicios.id"), nullable=False)
     hospital_id: Mapped[int] = mapped_column(ForeignKey("hospitales.id"), nullable=False)

--- a/app/routes/api/search.py
+++ b/app/routes/api/search.py
@@ -1,7 +1,9 @@
 """Asynchronous search endpoints for select widgets."""
 from __future__ import annotations
 
-from flask import jsonify, request
+import json
+
+from flask import current_app, jsonify, request
 from flask_login import login_required
 from sqlalchemy import asc, or_
 
@@ -10,17 +12,19 @@ from app.models import Hospital, Insumo, Oficina, Servicio
 from . import api_bp
 
 DEFAULT_PAGE_SIZE = 20
+LOOKUP_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 50
-LOOKUP_PAGE_SIZE = 100
 
 
 def _sanitize_query_param() -> str:
     query = request.args.get("q", "").strip()
+    if query == "...":
+        return ""
     return query[:80]
 
 
-def _get_page_size() -> int:
-    page_size = request.args.get("per_page", type=int, default=DEFAULT_PAGE_SIZE)
+def _get_page_size(default: int = DEFAULT_PAGE_SIZE) -> int:
+    page_size = request.args.get("per_page", type=int, default=default)
     return max(1, min(page_size, MAX_PAGE_SIZE))
 
 
@@ -29,13 +33,21 @@ def _format_hospital_label(hospital: Hospital) -> str:
     return f"{hospital.nombre} - {locality}" if locality else hospital.nombre
 
 
-def _paginate(query, page: int, per_page: int):
-    offset = max(page - 1, 0) * per_page
-    items = query.limit(per_page + 1).offset(offset).all()
-    has_next = len(items) > per_page
-    if has_next:
-        items = items[:-1]
-    return items, has_next
+def _build_paginated_response(pagination, formatter):
+    items = [formatter(item) for item in pagination.items]
+    return jsonify(
+        {
+            "items": items,
+            "page": pagination.page,
+            "pages": pagination.pages,
+            "total": pagination.total,
+        }
+    )
+
+
+def _log_missing_dependency(endpoint: str, **extra) -> None:
+    payload = {"endpoint": endpoint, "status": 400, **extra}
+    current_app.logger.warning(json.dumps(payload, ensure_ascii=False))
 
 
 @api_bp.route("/search/hospitales")
@@ -43,9 +55,10 @@ def _paginate(query, page: int, per_page: int):
 def search_hospitales():
     query_value = _sanitize_query_param()
     page = request.args.get("page", type=int, default=1)
+    per_page = _get_page_size()
 
     lookup = Hospital.query.order_by(asc(Hospital.nombre))
-    if query_value and query_value != "...":
+    if query_value:
         like = f"%{query_value}%"
         conditions = [Hospital.nombre.ilike(like)]
         localidad_column = getattr(Hospital, "localidad", None)
@@ -55,15 +68,11 @@ def search_hospitales():
         if direccion_column is not None and direccion_column not in conditions:
             conditions.append(direccion_column.ilike(like))
         lookup = lookup.filter(or_(*conditions))
-    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
-    results = [
-        {
-            "id": hospital.id,
-            "text": _format_hospital_label(hospital),
-        }
-        for hospital in items
-    ]
-    return jsonify({"results": results, "next": has_next})
+    pagination = lookup.paginate(page=page, per_page=per_page, error_out=False)
+    return _build_paginated_response(
+        pagination,
+        lambda hospital: {"id": hospital.id, "label": _format_hospital_label(hospital)},
+    )
 
 
 @api_bp.route("/search/servicios")
@@ -71,28 +80,38 @@ def search_hospitales():
 def search_servicios_lookup():
     hospital_id = request.args.get("hospital_id", type=int)
     if not hospital_id:
+        _log_missing_dependency(
+            "api.search_servicios_lookup", message="hospital_id es requerido"
+        )
         return (
-            jsonify({"results": [], "next": False, "message": "Seleccione un hospital"}),
+            jsonify(
+                {
+                    "items": [],
+                    "page": 1,
+                    "pages": 0,
+                    "total": 0,
+                    "message": "Seleccione un hospital",
+                }
+            ),
             400,
         )
 
     query_value = _sanitize_query_param()
     page = request.args.get("page", type=int, default=1)
+    per_page = _get_page_size(LOOKUP_PAGE_SIZE)
 
-    lookup = Servicio.query.filter(Servicio.hospital_id == hospital_id).order_by(asc(Servicio.nombre))
-    if query_value and query_value != "...":
+    lookup = (
+        Servicio.query.filter(Servicio.hospital_id == hospital_id)
+        .order_by(asc(Servicio.nombre))
+    )
+    if query_value:
         like = f"%{query_value}%"
         lookup = lookup.filter(Servicio.nombre.ilike(like))
 
-    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
-    results = [
-        {
-            "id": servicio.id,
-            "text": servicio.nombre,
-        }
-        for servicio in items
-    ]
-    return jsonify({"results": results, "next": has_next})
+    pagination = lookup.paginate(page=page, per_page=per_page, error_out=False)
+    return _build_paginated_response(
+        pagination, lambda servicio: {"id": servicio.id, "label": servicio.nombre}
+    )
 
 
 @api_bp.route("/search/oficinas")
@@ -100,31 +119,42 @@ def search_servicios_lookup():
 def search_oficinas_lookup():
     hospital_id = request.args.get("hospital_id", type=int)
     if not hospital_id:
+        _log_missing_dependency(
+            "api.search_oficinas_lookup", message="hospital_id es requerido"
+        )
         return (
-            jsonify({"results": [], "next": False, "message": "Seleccione un hospital"}),
+            jsonify(
+                {
+                    "items": [],
+                    "page": 1,
+                    "pages": 0,
+                    "total": 0,
+                    "message": "Seleccione un hospital",
+                }
+            ),
             400,
         )
     servicio_id = request.args.get("servicio_id", type=int)
 
     query_value = _sanitize_query_param()
     page = request.args.get("page", type=int, default=1)
+    per_page = _get_page_size(LOOKUP_PAGE_SIZE)
 
-    lookup = Oficina.query.filter(Oficina.hospital_id == hospital_id).order_by(asc(Oficina.nombre))
+    lookup = (
+        Oficina.query.filter(Oficina.hospital_id == hospital_id)
+        .order_by(asc(Oficina.nombre))
+    )
     if servicio_id:
         lookup = lookup.filter(Oficina.servicio_id == servicio_id)
-    if query_value and query_value != "...":
+    if query_value:
         like = f"%{query_value}%"
         lookup = lookup.filter(Oficina.nombre.ilike(like))
 
-    items, has_next = _paginate(lookup, page, LOOKUP_PAGE_SIZE)
-    results = [
-        {
-            "id": oficina.id,
-            "text": oficina.nombre,
-        }
-        for oficina in items
-    ]
-    return jsonify({"results": results, "next": has_next})
+    pagination = lookup.paginate(page=page, per_page=per_page, error_out=False)
+    return _build_paginated_response(
+        pagination,
+        lambda oficina: {"id": oficina.id, "label": oficina.nombre},
+    )
 
 
 @api_bp.route("/servicios/search")
@@ -140,14 +170,13 @@ def search_servicios():
         search = search.filter(Servicio.nombre.ilike(like))
 
     pagination = search.paginate(page=page, per_page=per_page, error_out=False)
-    results = [
-        {
+    return _build_paginated_response(
+        pagination,
+        lambda servicio: {
             "id": servicio.id,
-            "text": f"{servicio.hospital.nombre} · {servicio.nombre}",
-        }
-        for servicio in pagination.items
-    ]
-    return jsonify({"results": results, "next": pagination.has_next})
+            "label": f"{servicio.hospital.nombre} · {servicio.nombre}",
+        },
+    )
 
 
 @api_bp.route("/oficinas/search")
@@ -155,8 +184,19 @@ def search_servicios():
 def search_oficinas():
     servicio_id = request.args.get("servicio_id", type=int)
     if not servicio_id:
+        _log_missing_dependency(
+            "api.search_oficinas", message="servicio_id es requerido"
+        )
         return (
-            jsonify({"results": [], "next": False, "message": "Seleccione un servicio para filtrar oficinas"}),
+            jsonify(
+                {
+                    "items": [],
+                    "page": 1,
+                    "pages": 0,
+                    "total": 0,
+                    "message": "Seleccione un servicio para filtrar oficinas",
+                }
+            ),
             400,
         )
 
@@ -170,14 +210,13 @@ def search_oficinas():
         search = search.filter(Oficina.nombre.ilike(like))
 
     pagination = search.paginate(page=page, per_page=per_page, error_out=False)
-    results = [
-        {
+    return _build_paginated_response(
+        pagination,
+        lambda oficina: {
             "id": oficina.id,
-            "text": f"{oficina.hospital.nombre} · {oficina.nombre}",
-        }
-        for oficina in pagination.items
-    ]
-    return jsonify({"results": results, "next": pagination.has_next})
+            "label": f"{oficina.hospital.nombre} · {oficina.nombre}",
+        },
+    )
 
 
 @api_bp.route("/insumos/search")
@@ -193,11 +232,6 @@ def search_insumos():
         search = search.filter(Insumo.nombre.ilike(like))
 
     pagination = search.paginate(page=page, per_page=per_page, error_out=False)
-    results = [
-        {
-            "id": insumo.id,
-            "text": insumo.nombre,
-        }
-        for insumo in pagination.items
-    ]
-    return jsonify({"results": results, "next": pagination.has_next})
+    return _build_paginated_response(
+        pagination, lambda insumo: {"id": insumo.id, "label": insumo.nombre}
+    )

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -172,6 +172,19 @@ body {
   cursor: pointer;
 }
 
+.avatar-initials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #0d6efd;
+  color: #fff;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
 .object-fit-cover {
   object-fit: cover;
 }

--- a/app/static/js/forms/autocomplete.js
+++ b/app/static/js/forms/autocomplete.js
@@ -114,17 +114,17 @@
         }
         fetch(buildUrl(endpoint, params), { credentials: 'include' })
           .then((response) => {
-            if (!response.ok) {
-              return response.json().then((data) => {
-                const message = data.message || 'Sin resultados disponibles';
+            return response.json().then((data) => {
+              if (!response.ok) {
+                const message = data && data.message ? data.message : 'Sin resultados disponibles';
                 showDropdownMessage(tom, message);
-                return { results: [] };
-              });
-            }
-            return response.json();
+                return { items: [] };
+              }
+              return data;
+            });
           })
           .then((data) => {
-            callback(data.results || []);
+            callback(data.items || data.results || []);
           })
           .catch(() => {
             callback();

--- a/app/static/js/forms/equipos_form.js
+++ b/app/static/js/forms/equipos_form.js
@@ -1,0 +1,43 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('[data-serial-container]');
+    if (!container) {
+      return;
+    }
+    const serialInput = container.querySelector('[data-serial-input]');
+    const toggle = document.querySelector('[data-serial-toggle]');
+    const message = container.querySelector('[data-serial-message]');
+    if (!serialInput || !toggle) {
+      return;
+    }
+    const defaultMessage = message ? message.textContent : '';
+    const originalValue = serialInput.value;
+    let manualValue = serialInput.value;
+
+    serialInput.addEventListener('input', () => {
+      manualValue = serialInput.value;
+    });
+
+    function updateSerialState() {
+      const disabled = toggle.checked;
+      if (disabled) {
+        serialInput.setAttribute('disabled', 'disabled');
+        manualValue = serialInput.value;
+        if (message) {
+          message.textContent = originalValue ? `Código interno actual: ${originalValue}` : defaultMessage;
+          message.classList.remove('d-none');
+        }
+      } else {
+        serialInput.removeAttribute('disabled');
+        serialInput.value = manualValue;
+        if (message) {
+          message.textContent = defaultMessage;
+          message.classList.add('d-none');
+        }
+      }
+    }
+
+    toggle.addEventListener('change', updateSerialState);
+    updateSerialState();
+  });
+})();

--- a/app/templates/_form_helpers.html
+++ b/app/templates/_form_helpers.html
@@ -23,7 +23,7 @@
   {{ render_field(field, form_group_class=form_group_class, label_class=label_class, input_class=select_class|trim, extra_attrs=attrs) }}
 {%- endmacro %}
 
-{% macro render_lookup(field, hidden_field, endpoint, form_group_class='mb-3', label_class='form-label', placeholder='', params=None, required_params=None, reset_targets=None, requires_message=None, extra_attrs=None) -%}
+{% macro render_lookup(field, hidden_field, endpoint, form_group_class='mb-3', label_class='form-label', placeholder='', params=None, required_params=None, reset_targets=None, requires_message=None, extra_attrs=None, allow_empty=False, empty_label='Sin definir') -%}
   {% set attrs = {
     'class': 'form-control' ~ (' is-invalid' if field.errors else ''),
     'autocomplete': 'off',
@@ -43,6 +43,9 @@
   {% endif %}
   {% if requires_message %}
     {% set attrs = attrs | combine({'data-lookup-required-message': requires_message}) %}
+  {% endif %}
+  {% if allow_empty %}
+    {% set attrs = attrs | combine({'data-lookup-allow-empty': 'true', 'data-lookup-empty-label': empty_label}) %}
   {% endif %}
   {% if extra_attrs %}
     {% set attrs = attrs | combine(extra_attrs) %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}Inventario Hospitalario{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css">
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
     {% block styles %}{% endblock %}
   </head>
@@ -55,12 +56,26 @@
             </div>
           </div>
           {% if current_user.is_authenticated %}
-          <form class="d-none d-md-flex align-items-center" action="{{ url_for('search.search') }}" method="get">
-            <div class="input-group input-group-sm">
-              <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" name="q" value="{{ request.args.get('q', '') }}">
-              <button class="btn btn-outline-secondary" type="submit">Buscar</button>
+          <div class="d-flex align-items-center gap-3">
+            <form class="d-none d-md-flex align-items-center" action="{{ url_for('search.search') }}" method="get">
+              <div class="input-group input-group-sm">
+                <input class="form-control" type="search" placeholder="Buscar" aria-label="Buscar" name="q" value="{{ request.args.get('q', '') }}">
+                <button class="btn btn-outline-secondary" type="submit">Buscar</button>
+              </div>
+            </form>
+            <div class="dropdown">
+              {% set initials = ((current_user.nombre or current_user.username or '?')[:1]).upper() %}
+              <button class="btn btn-outline-secondary d-flex align-items-center gap-2" type="button" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="avatar-initials" aria-hidden="true">{{ initials }}</span>
+                <span class="d-none d-md-inline">{{ current_user.nombre }}</span>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+                <li><a class="dropdown-item" href="{{ url_for('main.perfil') }}">Mi perfil</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">Cerrar sesión</a></li>
+              </ul>
             </div>
-          </form>
+          </div>
           {% endif %}
         </header>
         <main class="app-content">
@@ -86,5 +101,28 @@
     <script src="{{ url_for('static', filename='js/lookups.js') }}"></script>
     <script src="{{ url_for('static', filename='js/forms/autocomplete.js') }}"></script>
     {% block scripts %}{% endblock %}
+    <div class="modal fade" id="lookupModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" data-lookup-modal-title>Seleccionar opción</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <input type="search" class="form-control" placeholder="Buscar…" data-lookup-modal-search aria-label="Buscar opciones">
+            </div>
+            <div class="list-group" data-lookup-modal-results role="listbox" aria-label="Resultados de búsqueda"></div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <div class="text-muted small" data-lookup-modal-summary></div>
+            <div class="btn-group">
+              <button type="button" class="btn btn-outline-secondary" data-lookup-modal-prev>Anterior</button>
+              <button type="button" class="btn btn-outline-secondary" data-lookup-modal-next>Siguiente</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/app/templates/equipos/actas.html
+++ b/app/templates/equipos/actas.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+{% from '_form_helpers.html' import render_select, render_field %}
+{% set query_args = request.args.to_dict(flat=True) %}
+{% block title %}Actas vinculadas{% endblock %}
+{% block header_title %}Actas vinculadas{% endblock %}
+{% block content %}
+<div class="mb-3">
+  <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('equipos.detalle', equipo_id=equipo.id) }}">&larr; Volver al equipo</a>
+</div>
+<form method="get" class="row g-3 mb-3 align-items-end">
+  {{ render_select(form.tipo, form_group_class='col-12 col-md-4') }}
+  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='date') }}
+  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='date') }}
+  <div class="col-12 col-md-2 d-flex gap-2">
+    {{ form.submit(class='btn btn-primary flex-grow-1') }}
+    <a class="btn btn-outline-secondary" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id) }}">Limpiar</a>
+  </div>
+</form>
+<div class="card">
+  <div class="card-body p-0">
+    <ul class="list-group list-group-flush">
+      {% for acta in actas %}
+      <li class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-start gap-2">
+        <div>
+          <strong>{{ normalize_enum_value(acta.tipo)|title }}</strong>
+          <div class="text-muted small">{{ acta.fecha.strftime('%d/%m/%Y') }}</div>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+          {% if acta.numero %}
+          <span class="badge bg-light text-dark">{{ acta.numero }}</span>
+          {% endif %}
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('actas.detalle', acta_id=acta.id) }}">Ver acta</a>
+        </div>
+      </li>
+      {% else %}
+      <li class="list-group-item text-muted">No hay actas que coincidan con los filtros indicados.</li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% if pagination.pages > 1 %}
+<nav class="mt-3" aria-label="Actas paginación">
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      {% if pagination.has_prev %}
+      <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': pagination.prev_num})) }}">Anterior</a>
+      {% else %}
+      <span class="page-link">Anterior</span>
+      {% endif %}
+    </li>
+    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+      {% if page_num %}
+        <li class="page-item{% if page_num == pagination.page %} active{% endif %}">
+          <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': page_num})) }}">{{ page_num }}</a>
+        </li>
+      {% else %}
+        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+      {% endif %}
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      {% if pagination.has_next %}
+      <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': pagination.next_num})) }}">Siguiente</a>
+      {% else %}
+      <span class="page-link">Siguiente</span>
+      {% endif %}
+    </li>
+  </ul>
+</nav>
+{% endif %}
+{% endblock %}

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -89,9 +89,12 @@
       <div class="card-header">Adjuntos</div>
       <ul class="list-group list-group-flush">
         {% for adjunto in adjuntos %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ adjunto.filename }} ({{ normalize_enum_value(adjunto.tipo) }})</span>
-          <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('adjuntos.descargar', adjunto_id=adjunto.id) }}">Descargar</a>
+        <li class="list-group-item d-flex flex-column gap-1">
+          <div class="d-flex justify-content-between align-items-start">
+            <span class="fw-semibold">{{ adjunto.filename }}</span>
+            <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('adjuntos.descargar', adjunto_id=adjunto.id) }}">Descargar</a>
+          </div>
+          <small class="text-muted">{{ normalize_enum_value(adjunto.tipo)|title }} · {{ adjunto.created_at.strftime('%d/%m/%Y %H:%M') if adjunto.created_at else '' }}</small>
         </li>
         {% else %}
         <li class="list-group-item text-muted">No hay documentos adjuntos.</li>
@@ -104,7 +107,7 @@
   <div class="card-header d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-2">
     <div>
       <h2 class="h6 mb-0">Evidencias del equipo</h2>
-      <p class="mb-0 text-muted small">Adjunte imágenes o PDF relacionados al equipo.</p>
+      <p class="mb-0 text-muted small">Adjunte imágenes o PDF relacionados al equipo. Tamaño máximo: {{ humanize_bytes(max_upload_size) }}.</p>
     </div>
     <form method="post" enctype="multipart/form-data" class="d-flex flex-wrap gap-2" action="{{ url_for('equipos.subir_adjunto', equipo_id=equipo.id) }}">
       {{ adjunto_form.hidden_tag() }}
@@ -123,21 +126,26 @@
           <div class="ratio ratio-4x3">
             <img src="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" alt="{{ archivo.filename }}" class="w-100 h-100 object-fit-cover rounded-top">
           </div>
+          {% elif archivo.mime_type == 'application/pdf' %}
+          <div class="ratio ratio-4x3 bg-light border-bottom">
+            <object data="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" type="application/pdf" class="w-100 h-100 rounded-top">PDF</object>
+          </div>
           {% else %}
           <div class="d-flex align-items-center justify-content-center py-4 bg-light border-bottom">
-            <span class="fw-semibold text-secondary">PDF</span>
+            <span class="fw-semibold text-secondary">Archivo</span>
           </div>
           {% endif %}
           <div class="card-body d-flex flex-column gap-2">
-            <div class="small" title="{{ archivo.filename }}">{{ archivo.filename }}</div>
+            <div class="small fw-semibold" title="{{ archivo.filename }}">{{ archivo.filename }}</div>
+            <div class="text-muted small">{{ humanize_bytes(archivo.size_in_bytes()) }} · {{ archivo.created_at.strftime('%d/%m/%Y %H:%M') if archivo.created_at else '' }}</div>
             <div class="d-flex flex-wrap gap-2">
               <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}">Descargar</a>
+              <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" target="_blank" rel="noopener">Ver</a>
               <form method="post" action="{{ url_for('equipos.eliminar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}" onsubmit="return confirm('¿Eliminar adjunto?');">
-                {{ csrf_token() }}
+                {{ delete_form.csrf_token(id='delete-token-' ~ archivo.id) }}
                 <button class="btn btn-sm btn-outline-danger" type="submit">Eliminar</button>
               </form>
             </div>
-            <small class="text-muted">Subido {{ archivo.created_at.strftime('%d/%m/%Y %H:%M') if archivo.created_at else '' }}</small>
           </div>
         </div>
       </div>
@@ -152,7 +160,12 @@
 <div class="row g-3 mt-3">
   <div class="col-md-6">
     <div class="card h-100">
-      <div class="card-header">Historial reciente</div>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Historial reciente</span>
+        {% if historial_total > historial|length %}
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id) }}">Ver todo</a>
+        {% endif %}
+      </div>
       <ul class="list-group list-group-flush">
         {% for entrada in historial %}
         <li class="list-group-item">
@@ -168,7 +181,12 @@
   </div>
   <div class="col-md-6">
     <div class="card h-100">
-      <div class="card-header">Actas vinculadas</div>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Actas vinculadas</span>
+        {% if actas_total > actas|length %}
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id) }}">Ver todo</a>
+        {% endif %}
+      </div>
       <ul class="list-group list-group-flush">
         {% for acta in actas %}
         <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/app/templates/equipos/formulario.html
+++ b/app/templates/equipos/formulario.html
@@ -6,11 +6,8 @@
 <form method="post" novalidate class="needs-validation">
   {{ form.hidden_tag() }}
   <div class="form-section">
-    <div class="section-header">Información general</div>
+    <div class="section-header">Ubicación</div>
     <div class="section-body row g-3">
-      {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3, placeholder='Descripción breve del equipo') }}
-      {{ render_select(form.tipo, form_group_class='col-12 col-md-6', label_class='form-label') }}
-      {{ render_select(form.estado, form_group_class='col-12 col-md-6', label_class='form-label') }}
       {{ render_lookup(
         form.hospital_busqueda,
         form.hospital_id,
@@ -31,7 +28,9 @@
         params={'hospital_id': form.hospital_id.id},
         required_params=['hospital_id'],
         reset_targets=[form.oficina_busqueda.id],
-        requires_message='Seleccione un hospital para buscar servicios'
+        requires_message='Seleccione un hospital para buscar servicios',
+        allow_empty=True,
+        empty_label='Sin definir'
       ) }}
       {{ render_lookup(
         form.oficina_busqueda,
@@ -41,27 +40,47 @@
         placeholder='Buscar oficina',
         params={'hospital_id': form.hospital_id.id, 'servicio_id': form.servicio_id.id},
         required_params=['hospital_id'],
-        requires_message='Seleccione un hospital para buscar oficinas'
+        requires_message='Seleccione un hospital para buscar oficinas',
+        allow_empty=True,
+        empty_label='Sin definir'
       ) }}
       {{ render_field(form.responsable, form_group_class='col-12 col-md-6', placeholder='Responsable del equipo') }}
     </div>
   </div>
   <div class="form-section">
-    <div class="section-header">Características técnicas</div>
+    <div class="section-header">Identificación y estado</div>
     <div class="section-body row g-3">
-      {{ render_field(form.marca, form_group_class='col-12 col-md-4', placeholder='Marca') }}
-      {{ render_field(form.modelo, form_group_class='col-12 col-md-4', placeholder='Modelo') }}
-      {{ render_field(form.numero_serie, form_group_class='col-12 col-md-4', placeholder='Número de serie') }}
-      {{ render_checkbox(form.sin_numero_serie, form_group_class='col-12 col-md-4 align-self-end') }}
-      {{ render_field(form.fecha_compra, form_group_class='col-12 col-md-4', input_type='date') }}
-      {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='date') }}
-      {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='date') }}
+      <div class="col-12 col-md-6" data-serial-container>
+        <label class="form-label" for="{{ form.numero_serie.id }}">Número de serie</label>
+        {{ render_input_field(form.numero_serie, 'form-control' ~ (' is-invalid' if form.numero_serie.errors else ''), placeholder='Número de serie', extra_attrs={'data-serial-input': 'true'}) }}
+        <div class="form-text d-none" data-serial-message>Se generará un código interno al guardar.</div>
+        {% for error in form.numero_serie.errors %}
+        <div class="invalid-feedback d-block">{{ error }}</div>
+        {% endfor %}
+      </div>
+      <div class="col-12 col-md-6 align-self-end">
+        <div class="form-check mb-0">
+          {{ render_input_field(form.sin_numero_serie, 'form-check-input' ~ (' is-invalid' if form.sin_numero_serie.errors else ''), extra_attrs={'data-serial-toggle': 'true'}) }}
+          {{ form.sin_numero_serie.label(class='form-check-label') }}
+          {% for error in form.sin_numero_serie.errors %}
+          <div class="invalid-feedback d-block">{{ error }}</div>
+          {% endfor %}
+        </div>
+      </div>
+      {{ render_field(form.codigo, form_group_class='col-12 col-md-6', placeholder='Código patrimonial') }}
+      {{ render_select(form.tipo, form_group_class='col-12 col-md-3', label_class='form-label') }}
+      {{ render_select(form.estado, form_group_class='col-12 col-md-3', label_class='form-label') }}
     </div>
   </div>
   <div class="form-section">
-    <div class="section-header">Identificación</div>
+    <div class="section-header">Detalles del equipo</div>
     <div class="section-body row g-3">
-      {{ render_field(form.codigo, form_group_class='col-12 col-md-6', placeholder='Código patrimonial') }}
+      {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3, placeholder='Descripción breve del equipo') }}
+      {{ render_field(form.marca, form_group_class='col-12 col-md-4', placeholder='Marca') }}
+      {{ render_field(form.modelo, form_group_class='col-12 col-md-4', placeholder='Modelo') }}
+      {{ render_field(form.fecha_compra, form_group_class='col-12 col-md-4', input_type='date') }}
+      {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='date') }}
+      {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_textarea(form.observaciones, form_group_class='col-12', rows=3, placeholder='Observaciones relevantes') }}
     </div>
   </div>
@@ -70,4 +89,8 @@
     <a class="btn btn-outline-secondary" href="{{ url_for('equipos.listar') }}">Cancelar</a>
   </div>
 </form>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/forms/equipos_form.js') }}"></script>
 {% endblock %}

--- a/app/templates/equipos/historial.html
+++ b/app/templates/equipos/historial.html
@@ -1,0 +1,72 @@
+{% extends 'base.html' %}
+{% from '_form_helpers.html' import render_field %}
+{% set query_args = request.args.to_dict(flat=True) %}
+{% block title %}Historial del equipo{% endblock %}
+{% block header_title %}Historial del equipo{% endblock %}
+{% block content %}
+<div class="mb-3">
+  <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('equipos.detalle', equipo_id=equipo.id) }}">&larr; Volver al equipo</a>
+</div>
+<form method="get" class="row g-3 mb-3 align-items-end">
+  {{ render_field(form.accion, form_group_class='col-12 col-md-4', placeholder='Filtrar por acción o descripción') }}
+  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='date') }}
+  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='date') }}
+  <div class="col-12 col-md-2 d-flex gap-2">
+    {{ form.submit(class='btn btn-primary flex-grow-1') }}
+    <a class="btn btn-outline-secondary" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id) }}">Limpiar</a>
+  </div>
+</form>
+<div class="card">
+  <div class="card-body p-0">
+    <ul class="list-group list-group-flush">
+      {% for registro in registros %}
+      <li class="list-group-item">
+        <div class="d-flex justify-content-between flex-column flex-md-row gap-2">
+          <div>
+            <strong>{{ registro.accion }}</strong>
+            {% if registro.descripcion %}
+            <div class="text-muted small">{{ registro.descripcion }}</div>
+            {% endif %}
+          </div>
+          <div class="text-muted small text-md-end">
+            {{ registro.fecha.strftime('%d/%m/%Y %H:%M') if registro.fecha else '' }}
+            {% if registro.usuario %}<br>Por {{ registro.usuario.nombre }}{% endif %}
+          </div>
+        </div>
+      </li>
+      {% else %}
+      <li class="list-group-item text-muted">No se encontraron registros para los filtros seleccionados.</li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% if pagination.pages > 1 %}
+<nav class="mt-3" aria-label="Historial paginación">
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      {% if pagination.has_prev %}
+      <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': pagination.prev_num})) }}">Anterior</a>
+      {% else %}
+      <span class="page-link">Anterior</span>
+      {% endif %}
+    </li>
+    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+      {% if page_num %}
+        <li class="page-item{% if page_num == pagination.page %} active{% endif %}">
+          <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': page_num})) }}">{{ page_num }}</a>
+        </li>
+      {% else %}
+        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+      {% endif %}
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      {% if pagination.has_next %}
+      <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': pagination.next_num})) }}">Siguiente</a>
+      {% else %}
+      <span class="page-link">Siguiente</span>
+      {% endif %}
+    </li>
+  </ul>
+</nav>
+{% endif %}
+{% endblock %}

--- a/app/templates/usuarios/perfil.html
+++ b/app/templates/usuarios/perfil.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% from '_form_helpers.html' import render_field %}
+{% block title %}Mi perfil{% endblock %}
+{% block header_title %}Mi perfil{% endblock %}
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <form method="post" novalidate class="row g-3 needs-validation">
+      {{ form.hidden_tag() }}
+      {{ render_field(form.nombre, form_group_class='col-12 col-md-6', placeholder='Nombre') }}
+      {{ render_field(form.apellido, form_group_class='col-12 col-md-6', placeholder='Apellido') }}
+      {{ render_field(form.email, form_group_class='col-12 col-md-6', placeholder='Correo electrónico') }}
+      {{ render_field(form.telefono, form_group_class='col-12 col-md-6', placeholder='Teléfono de contacto') }}
+      {{ render_field(form.password, form_group_class='col-12 col-md-6', input_type='password', placeholder='Nueva contraseña (opcional)') }}
+      {{ render_field(form.confirm_password, form_group_class='col-12 col-md-6', input_type='password', placeholder='Confirmar contraseña') }}
+      <div class="col-12 d-flex flex-column flex-md-row gap-2 justify-content-end">
+        {{ form.submit(class='btn btn-primary px-4') }}
+        <a class="btn btn-outline-secondary" href="{{ url_for('main.index') }}">Cancelar</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -2,11 +2,27 @@
 
 from __future__ import annotations
 
+from math import log
 from urllib.parse import urljoin, urlparse
 
 from flask import Request, request
 
 from .forms import build_select_attrs, render_input_field
+
+
+def humanize_bytes(size: int | None) -> str:
+    """Return a human readable label for ``size`` measured in bytes."""
+
+    if size is None or size < 0:
+        return "—"
+    if size == 0:
+        return "0 B"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    idx = min(int(log(size, 1024)), len(units) - 1)
+    scaled = size / (1024 ** idx)
+    if idx == 0:
+        return f"{int(scaled)} {units[idx]}"
+    return f"{scaled:.1f} {units[idx]}"
 
 
 def normalize_enum_value(value: object) -> str:
@@ -47,4 +63,5 @@ __all__ = [
     "build_select_attrs",
     "normalize_enum_value",
     "is_safe_redirect_target",
+    "humanize_bytes",
 ]

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Config:
     ADJUNTOS_SUBFOLDER: str = os.getenv("ADJUNTOS_SUBFOLDER", "adjuntos")
     DOCSCAN_SUBFOLDER: str = os.getenv("DOCSCAN_SUBFOLDER", "docscan")
     EQUIPOS_SUBFOLDER: str = os.getenv("EQUIPOS_SUBFOLDER", "equipos")
+    EQUIPOS_MAX_FILE_SIZE: int = int(os.getenv("EQUIPOS_MAX_FILE_SIZE", 10 * 1024 * 1024))
     MAX_CONTENT_LENGTH: int = int(os.getenv("MAX_CONTENT_LENGTH", 16 * 1024 * 1024))
     ALLOWED_EXTENSIONS: set[str] = set(
         os.getenv("ALLOWED_EXTENSIONS", "pdf,jpg,jpeg,png").split(",")

--- a/migrations/versions/c6be45c2d4ab_equipos_lookup_updates.py
+++ b/migrations/versions/c6be45c2d4ab_equipos_lookup_updates.py
@@ -1,0 +1,29 @@
+"""Add attachment metadata and lookup indexes"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c6be45c2d4ab"
+down_revision = "bd8b7d50f9ac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("equipos_adjuntos", recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("file_size", sa.Integer(), nullable=True))
+
+    op.create_index("ix_servicios_nombre", "servicios", ["nombre"], unique=False)
+    op.create_index("ix_oficinas_nombre", "oficinas", ["nombre"], unique=False)
+    op.create_index("ix_hospitales_direccion", "hospitales", ["direccion"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_hospitales_direccion", table_name="hospitales")
+    op.drop_index("ix_oficinas_nombre", table_name="oficinas")
+    op.drop_index("ix_servicios_nombre", table_name="servicios")
+
+    with op.batch_alter_table("equipos_adjuntos", recreate="always") as batch_op:
+        batch_op.drop_column("file_size")

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -11,8 +11,9 @@ def test_search_servicios_endpoint(client, admin_credentials):
     resp = client.get("/api/servicios/search?q=eme")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data["results"]
-    assert any("Emergencias" in item["text"] for item in data["results"])
+    assert data["items"]
+    assert any("Emergencias" in item["label"] for item in data["items"])
+    assert data["total"] >= len(data["items"])
 
 
 def test_search_hospitales_lookup(client, admin_credentials):
@@ -20,10 +21,10 @@ def test_search_hospitales_lookup(client, admin_credentials):
     resp = client.get("/api/search/hospitales?q=Central")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert any("Hospital Central" in item["text"] for item in data["results"])
+    assert any("Hospital Central" in item["label"] for item in data["items"])
     resp_all = client.get("/api/search/hospitales?q=...")
     assert resp_all.status_code == 200
-    assert resp_all.get_json()["results"]
+    assert resp_all.get_json()["items"]
 
 
 def test_search_servicios_lookup_requires_hospital(client, admin_credentials, data):
@@ -34,7 +35,7 @@ def test_search_servicios_lookup_requires_hospital(client, admin_credentials, da
     resp_ok = client.get(f"/api/search/servicios?hospital_id={hospital_id}&q=eme")
     assert resp_ok.status_code == 200
     payload = resp_ok.get_json()
-    assert any(item["text"] == "Emergencias" for item in payload["results"])
+    assert any(item["label"] == "Emergencias" for item in payload["items"])
 
 
 def test_search_oficinas_lookup_requires_hospital(client, admin_credentials, data):
@@ -48,7 +49,7 @@ def test_search_oficinas_lookup_requires_hospital(client, admin_credentials, dat
     )
     assert resp_ok.status_code == 200
     payload = resp_ok.get_json()
-    assert payload["results"]
+    assert payload["items"]
 
 
 def test_search_oficinas_requires_servicio(client, admin_credentials, data):
@@ -59,7 +60,7 @@ def test_search_oficinas_requires_servicio(client, admin_credentials, data):
     resp = client.get(f"/api/oficinas/search?servicio_id={servicio_id}&q=principal")
     assert resp.status_code == 200
     payload = resp.get_json()
-    assert payload["results"]
+    assert payload["items"]
 
 
 def test_search_insumos_endpoint(client, admin_credentials):
@@ -67,4 +68,4 @@ def test_search_insumos_endpoint(client, admin_credentials):
     resp = client.get("/api/insumos/search?q=mouse")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert any("Mouse" in item["text"] for item in data["results"])
+    assert any("Mouse" in item["label"] for item in data["items"])

--- a/tests/test_equipos.py
+++ b/tests/test_equipos.py
@@ -45,7 +45,7 @@ def test_equipo_generates_internal_serial(client, admin_credentials, data):
     nuevo = Equipo.query.order_by(Equipo.id.desc()).first()
     assert nuevo is not None
     assert nuevo.sin_numero_serie is True
-    assert nuevo.numero_serie and nuevo.numero_serie.startswith("SNV-")
+    assert nuevo.numero_serie and nuevo.numero_serie.startswith("EQ-")
 
 
 def test_equipo_requires_valid_hospital_lookup(client, admin_credentials, data):


### PR DESCRIPTION
## Summary
- expand `/api/search/*` endpoints to return uniform paginated payloads with dependency validation and structured logging
- enforce serial-number validation, internal-code generation, and dependency-aware equipment forms plus streamlined templates
- redesign equipment detail view with CSRF-protected attachment management, inline previews, limited history/acta listings, and supporting assets
- add profile dropdown, `/perfil` page, favicon generated from embedded base64 data, LAN-ready notes, and Alembic migration for lookup enhancements
- align the `/api/search/oficinas` dependency error payload with the new paginated response schema for consistency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cf9271dc8324bd3d9208337e1ee8