### PR TITLE
Remove avatar button from navbar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -148,10 +148,8 @@
               </div>
             </form>
             <div class="dropdown">
-              {% set initials = ((current_user.nombre or current_user.username or '?')[:1]).upper() %}
-              <button class="btn btn-outline-secondary d-flex align-items-center gap-2" type="button" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                <span class="avatar-initials" aria-hidden="true">{{ initials }}</span>
-                <span class="d-none d-md-inline">{{ current_user.nombre }}</span>
+              <button class="btn btn-outline-secondary" type="button" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                {{ current_user.nombre }}
               </button>
               <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
                 <li><a class="dropdown-item" href="{{ url_for('main.perfil') }}">Mi perfil</a></li>


### PR DESCRIPTION
## Summary
- simplify the profile dropdown by removing the avatar/initials button so only the user name is shown in the header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d510182fc08324a7b4b9a58a4ab3d4