### PR TITLE
Add license management UIs and theme preference support

### DIFF
--- a/app/forms/licencia.py
+++ b/app/forms/licencia.py
@@ -20,6 +20,12 @@ class LicenciaForm(FlaskForm):
     )
     fecha_inicio = DateField("Fecha de inicio", validators=[DataRequired()])
     fecha_fin = DateField("Fecha de fin", validators=[DataRequired()])
+    hospital_id = SelectField(
+        "Hospital",
+        coerce=int,
+        validators=[Optional()],
+        description="Opcional si la licencia está asociada a un hospital específico.",
+    )
     motivo = TextAreaField("Motivo", validators=[DataRequired(), Length(max=500)])
     submit = SubmitField("Enviar solicitud")
 
@@ -46,4 +52,70 @@ class CalendarioFiltroForm(FlaskForm):
     submit = SubmitField("Filtrar")
 
 
-__all__ = ["LicenciaForm", "AprobarRechazarForm", "CalendarioFiltroForm"]
+class MisLicenciasFiltroForm(FlaskForm):
+    """Basic filters for the "mis licencias" listing."""
+
+    estado = SelectField(
+        "Estado",
+        choices=[],
+        validators=[Optional()],
+        description="Filtrar por estado actual de la solicitud.",
+    )
+    tipo = SelectField(
+        "Tipo",
+        choices=[],
+        validators=[Optional()],
+        description="Filtrar por tipo de licencia.",
+    )
+    fecha_desde = DateField("Desde", validators=[Optional()])
+    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    submit = SubmitField("Aplicar filtros")
+
+
+class GestionLicenciasFiltroForm(FlaskForm):
+    """Filters for the superadmin management board."""
+
+    usuario_id = SelectField(
+        "Usuario",
+        coerce=lambda value: int(value) if value else None,
+        choices=[],
+        validators=[Optional()],
+    )
+    hospital_id = SelectField(
+        "Hospital",
+        coerce=lambda value: int(value) if value else None,
+        choices=[],
+        validators=[Optional()],
+    )
+    estado = SelectField("Estado", choices=[], validators=[Optional()])
+    fecha_desde = DateField("Desde", validators=[Optional()])
+    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    submit = SubmitField("Aplicar filtros")
+
+
+class LicenciaAccionForm(FlaskForm):
+    """Simple action form that only carries the CSRF token."""
+
+    submit = SubmitField()
+
+
+class LicenciaRechazoForm(FlaskForm):
+    """Form used to capture an optional rejection reason."""
+
+    motivo_rechazo = TextAreaField(
+        "Motivo de rechazo",
+        validators=[Optional(), Length(max=500)],
+        description="Se enviará al solicitante junto con la notificación de rechazo.",
+    )
+    submit = SubmitField("Confirmar rechazo")
+
+
+__all__ = [
+    "LicenciaForm",
+    "AprobarRechazarForm",
+    "CalendarioFiltroForm",
+    "MisLicenciasFiltroForm",
+    "GestionLicenciasFiltroForm",
+    "LicenciaAccionForm",
+    "LicenciaRechazoForm",
+]

--- a/app/models/licencia.py
+++ b/app/models/licencia.py
@@ -58,6 +58,7 @@ class Licencia(Base):
         server_default=EstadoLicencia.SOLICITADA.value,
         nullable=False,
     )
+    motivo_rechazo: Mapped[str | None] = mapped_column(Text())
     decidido_por: Mapped[int | None] = mapped_column(ForeignKey("usuarios.id"))
     decidido_en: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(
@@ -100,7 +101,7 @@ class Licencia(Base):
         self.decisor = aprobador
         self.decidido_en = fecha or datetime.utcnow()
 
-    def rechazar(self, aprobador: "Usuario") -> None:
+    def rechazar(self, aprobador: "Usuario", motivo: str | None = None) -> None:
         """Reject the license request."""
 
         if self.estado != EstadoLicencia.SOLICITADA:
@@ -108,6 +109,7 @@ class Licencia(Base):
         self.estado = EstadoLicencia.RECHAZADA
         self.decisor = aprobador
         self.decidido_en = datetime.utcnow()
+        self.motivo_rechazo = (motivo or "").strip() or None
 
     def cancelar(self, usuario: "Usuario") -> None:
         """Cancel the license request."""

--- a/app/models/usuario.py
+++ b/app/models/usuario.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import Iterable, TYPE_CHECKING
 
 from flask_login import UserMixin
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, Enum as SAEnum, ForeignKey, String, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from werkzeug.security import check_password_hash as wz_check_password_hash
 from werkzeug.security import generate_password_hash as wz_generate_password_hash
@@ -13,6 +14,14 @@ from werkzeug.security import generate_password_hash as wz_generate_password_has
 from app.extensions import bcrypt
 
 from .base import Base
+
+
+class ThemePreference(str, Enum):
+    """Available theme options for the UI."""
+
+    LIGHT = "light"
+    DARK = "dark"
+    SYSTEM = "system"
 
 if TYPE_CHECKING:  # pragma: no cover
     from .hospital import Hospital, Oficina, Servicio
@@ -39,6 +48,12 @@ class Usuario(Base, UserMixin):
     hospital_id: Mapped[int | None] = mapped_column(ForeignKey("hospitales.id"))
     servicio_id: Mapped[int | None] = mapped_column(ForeignKey("servicios.id"))
     oficina_id: Mapped[int | None] = mapped_column(ForeignKey("oficinas.id"))
+    theme_pref: Mapped[ThemePreference] = mapped_column(
+        SAEnum(ThemePreference, name="theme_preference"),
+        default=ThemePreference.SYSTEM,
+        server_default=ThemePreference.SYSTEM.value,
+        nullable=False,
+    )
     ultimo_login: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
@@ -137,4 +152,4 @@ class Usuario(Base, UserMixin):
         self.rol.permisos = list(permisos)
 
 
-__all__ = ["Usuario"]
+__all__ = ["Usuario", "ThemePreference"]

--- a/app/routes/api/__init__.py
+++ b/app/routes/api/__init__.py
@@ -5,6 +5,6 @@ from flask import Blueprint
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
-from . import dashboard, search  # noqa: E402  pylint: disable=wrong-import-position
+from . import dashboard, licencias, search  # noqa: E402  pylint: disable=wrong-import-position
 
 __all__ = ["api_bp"]

--- a/app/routes/api/licencias.py
+++ b/app/routes/api/licencias.py
@@ -1,0 +1,104 @@
+"""API endpoints to expose license information."""
+from __future__ import annotations
+
+from datetime import date
+
+from flask import abort, jsonify, request
+from flask_login import current_user, login_required
+
+from app.models import EstadoLicencia, Licencia, TipoLicencia
+
+from . import api_bp
+
+
+def _parse_enum(value: str | None, enum_cls):
+    if not value:
+        return None
+    try:
+        return enum_cls(value)
+    except ValueError as exc:  # pragma: no cover - defensive
+        abort(400, description=str(exc))
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:  # pragma: no cover - defensive
+        abort(400, description="Formato de fecha inválido. Use AAAA-MM-DD.")
+
+
+def _serialize(licencia: Licencia) -> dict[str, object]:
+    return {
+        "id": licencia.id,
+        "tipo": licencia.tipo.value,
+        "estado": licencia.estado.value,
+        "fecha_inicio": licencia.fecha_inicio.isoformat(),
+        "fecha_fin": licencia.fecha_fin.isoformat(),
+        "motivo": licencia.motivo,
+        "motivo_rechazo": licencia.motivo_rechazo,
+        "hospital": licencia.hospital.nombre if licencia.hospital else None,
+        "usuario": licencia.usuario.nombre if licencia.usuario else None,
+        "decidido_por": licencia.decisor.nombre if licencia.decisor else None,
+        "decidido_en": licencia.decidido_en.isoformat() if licencia.decidido_en else None,
+    }
+
+
+@api_bp.get("/licencias/mias")
+@login_required
+def api_mis_licencias():
+    """Return the current user's license requests in JSON format."""
+
+    query = Licencia.query.filter(Licencia.user_id == current_user.id)
+
+    estado = _parse_enum(request.args.get("estado"), EstadoLicencia)
+    tipo = _parse_enum(request.args.get("tipo"), TipoLicencia)
+    fecha_desde = _parse_date(request.args.get("desde"))
+    fecha_hasta = _parse_date(request.args.get("hasta"))
+
+    if estado:
+        query = query.filter(Licencia.estado == estado)
+    if tipo:
+        query = query.filter(Licencia.tipo == tipo)
+    if fecha_desde:
+        query = query.filter(Licencia.fecha_fin >= fecha_desde)
+    if fecha_hasta:
+        query = query.filter(Licencia.fecha_inicio <= fecha_hasta)
+
+    licencias = query.order_by(Licencia.created_at.desc()).all()
+    return jsonify({"licencias": [_serialize(licencia) for licencia in licencias]})
+
+
+@api_bp.get("/licencias/admin")
+@login_required
+def api_licencias_admin():
+    """Expose the admin view of licenses for superadmin users."""
+
+    if not current_user.has_role("superadmin"):
+        abort(403)
+
+    query = Licencia.query
+
+    estado = _parse_enum(request.args.get("estado"), EstadoLicencia)
+    tipo = _parse_enum(request.args.get("tipo"), TipoLicencia)
+    usuario_id = request.args.get("usuario_id", type=int)
+    hospital_id = request.args.get("hospital_id", type=int)
+    fecha_desde = _parse_date(request.args.get("desde"))
+    fecha_hasta = _parse_date(request.args.get("hasta"))
+
+    if estado:
+        query = query.filter(Licencia.estado == estado)
+    if tipo:
+        query = query.filter(Licencia.tipo == tipo)
+    if usuario_id:
+        query = query.filter(Licencia.user_id == usuario_id)
+    if hospital_id:
+        query = query.filter(Licencia.hospital_id == hospital_id)
+    if fecha_desde:
+        query = query.filter(Licencia.fecha_fin >= fecha_desde)
+    if fecha_hasta:
+        query = query.filter(Licencia.fecha_inicio <= fecha_hasta)
+
+    licencias = query.order_by(Licencia.created_at.desc()).all()
+    return jsonify({"licencias": [_serialize(licencia) for licencia in licencias]})

--- a/app/routes/licencias/__init__.py
+++ b/app/routes/licencias/__init__.py
@@ -1,0 +1,5 @@
+"""Licencias blueprint export."""
+
+from .routes import licencias_bp
+
+__all__ = ["licencias_bp"]

--- a/app/services/licencia_service.py
+++ b/app/services/licencia_service.py
@@ -72,8 +72,10 @@ def aprobar_licencia(licencia: Licencia, aprobador: Usuario) -> Licencia:
     return licencia
 
 
-def rechazar_licencia(licencia: Licencia, aprobador: Usuario) -> Licencia:
-    licencia.rechazar(aprobador)
+def rechazar_licencia(
+    licencia: Licencia, aprobador: Usuario, motivo: str | None = None
+) -> Licencia:
+    licencia.rechazar(aprobador, motivo)
     db.session.commit()
     return licencia
 

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,0 +1,51 @@
+(function () {
+  const doc = document.documentElement;
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function systemTheme() {
+    return prefersDark.matches ? 'dark' : 'light';
+  }
+
+  function applyTheme(theme) {
+    const effective = theme === 'system' ? systemTheme() : theme;
+    doc.dataset.themePref = theme;
+    doc.setAttribute('data-bs-theme', effective);
+    document
+      .querySelectorAll('[data-theme-option]')
+      .forEach((btn) => btn.classList.toggle('active', btn.getAttribute('data-theme-option') === theme));
+  }
+
+  function persistTheme(theme) {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    fetch('/preferencias/tema', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken,
+      },
+      body: JSON.stringify({ theme }),
+    }).catch(() => {
+      // Network failures shouldn't break the UI; the preference will be retried on next change.
+    });
+  }
+
+  applyTheme(doc.dataset.themePref || 'system');
+
+  prefersDark.addEventListener('change', () => {
+    if (doc.dataset.themePref === 'system') {
+      applyTheme('system');
+    }
+  });
+
+  document.querySelectorAll('[data-theme-option]').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const theme = btn.getAttribute('data-theme-option');
+      if (!theme) {
+        return;
+      }
+      applyTheme(theme);
+      persistTheme(theme);
+    });
+  });
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,10 @@
 <!doctype html>
-<html lang="es">
+{% set theme_pref = current_user.theme_pref.value if current_user.is_authenticated else 'system' %}
+{% set theme_initial = 'dark' if theme_pref == 'dark' else 'light' %}
+{% if theme_pref == 'system' %}
+  {% set theme_initial = 'light' %}
+{% endif %}
+<html lang="es" data-theme-pref="{{ theme_pref }}" data-bs-theme="{{ theme_initial }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -30,6 +35,11 @@
         {% set usuarios_open = current_bp in ['usuarios', 'licencias', 'permisos'] %}
         {% set vista_actual = request.args.get('vista', 'hospitales') %}
         {% set filtro_insumos = request.args.get('criticos') %}
+        {% if has_role('superadmin') %}
+        {% set licencias_url = url_for('licencias.gestion') %}
+        {% else %}
+        {% set licencias_url = url_for('licencias.mias') %}
+        {% endif %}
         <nav class="sidebar-nav" aria-label="Menú principal">
           <ul class="sidebar-nav-list list-unstyled mb-0">
             <li>
@@ -101,7 +111,7 @@
                   <ul class="sidebar-subnav list-unstyled mb-0">
                     <li><a class="sidebar-sublink{% if current_bp == 'usuarios' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('usuarios.listar') }}">Listado</a></li>
                     <li><a class="sidebar-sublink{% if current_endpoint == 'usuarios.crear' %} active{% endif %}" href="{{ url_for('usuarios.crear') }}">Nuevo usuario</a></li>
-                    <li><a class="sidebar-sublink{% if current_bp == 'licencias' %} active{% endif %}" href="{{ url_for('licencias.listar') }}">Licencias</a></li>
+                    <li><a class="sidebar-sublink{% if current_bp == 'licencias' %} active{% endif %}" href="{{ licencias_url }}">Licencias</a></li>
                     {% if has_role('superadmin') %}
                     <li><a class="sidebar-sublink{% if current_bp == 'permisos' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('permisos.listar') }}">Permisos</a></li>
                     {% endif %}
@@ -153,6 +163,15 @@
               </button>
               <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
                 <li><a class="dropdown-item" href="{{ url_for('main.perfil') }}">Mi perfil</a></li>
+                <li><a class="dropdown-item" href="{{ licencias_url }}">Licencias</a></li>
+                <li><span class="dropdown-header">Cambiar tema</span></li>
+                <li class="px-3 pb-2">
+                  <div class="btn-group btn-group-sm w-100" role="group" aria-label="Cambiar tema">
+                    <button type="button" class="btn btn-outline-secondary" data-theme-option="light">Claro</button>
+                    <button type="button" class="btn btn-outline-secondary" data-theme-option="dark">Oscuro</button>
+                    <button type="button" class="btn btn-outline-secondary" data-theme-option="system">Sistema</button>
+                  </div>
+                </li>
                 <li><hr class="dropdown-divider"></li>
                 <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">Cerrar sesión</a></li>
               </ul>
@@ -179,6 +198,7 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
     <script src="{{ url_for('static', filename='js/layout.js') }}"></script>
     <script src="{{ url_for('static', filename='js/lookups.js') }}"></script>
     <script src="{{ url_for('static', filename='js/forms/autocomplete.js') }}"></script>

--- a/app/templates/licencias/gestion.html
+++ b/app/templates/licencias/gestion.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% from "_form_helpers.html" import render_select, render_field %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block title %}Gestión de licencias{% endblock %}
+{% block header_title %}Gestión de licencias{% endblock %}
+
+{% block content %}
+<div class="card mb-4">
+  <div class="card-body">
+    <form class="row g-3 align-items-end" method="get" action="{{ url_for('licencias.gestion') }}">
+      <div class="col-12 col-lg-3">
+        {{ render_select(form.usuario_id, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
+      </div>
+      <div class="col-12 col-lg-3">
+        {{ render_select(form.hospital_id, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
+      </div>
+      <div class="col-6 col-lg-2">
+        {{ render_select(form.estado, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
+      </div>
+      <div class="col-6 col-lg-2">
+        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+      </div>
+      <div class="col-6 col-lg-2">
+        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+      </div>
+      <div class="col-12 col-lg-2 d-flex gap-2">
+        {{ form.submit(class_='btn btn-primary btn-sm flex-grow-1') }}
+        <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('licencias.gestion') }}">Limpiar</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    {% if pagination.items %}
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th scope="col">ID</th>
+            <th scope="col">Usuario</th>
+            <th scope="col">Hospital</th>
+            <th scope="col">Período</th>
+            <th scope="col">Tipo</th>
+            <th scope="col">Estado</th>
+            <th scope="col">Detalle</th>
+            <th scope="col" class="text-end">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for licencia in pagination.items %}
+          <tr>
+            <td class="fw-semibold">#{{ licencia.id }}</td>
+            <td>
+              <div class="fw-semibold">{{ licencia.usuario.nombre }} {{ licencia.usuario.apellido or '' }}</div>
+              <div class="text-muted small">{{ licencia.usuario.email }}</div>
+            </td>
+            <td>{{ licencia.hospital.nombre if licencia.hospital else '—' }}</td>
+            <td>{{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} – {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</td>
+            <td>{{ normalize_enum_value(licencia.tipo) }}</td>
+            <td>
+              <span class="badge bg-{{ badge_for(licencia.estado) }}">{{ normalize_enum_value(licencia.estado) }}</span>
+              {% if licencia.decisor %}
+              <div class="small text-muted mt-1">{{ licencia.decisor.nombre }}{% if licencia.decidido_en %}, {{ licencia.decidido_en.strftime('%d/%m/%Y %H:%M') }}{% endif %}</div>
+              {% endif %}
+            </td>
+            <td class="text-wrap">
+              <div class="small text-muted">Motivo</div>
+              <div>{{ licencia.motivo }}</div>
+              {% if licencia.motivo_rechazo %}
+              <div class="small text-muted mt-2">Motivo de rechazo</div>
+              <div class="text-danger">{{ licencia.motivo_rechazo }}</div>
+              {% endif %}
+            </td>
+            <td class="text-end">
+              <div class="d-flex flex-column gap-2 align-items-end">
+                {% if licencia.estado == EstadoLicencia.SOLICITADA %}
+                <form method="post" action="{{ url_for('licencias.aprobar', licencia_id=licencia.id) }}" class="d-inline">
+                  {{ aprobar_form.csrf_token }}
+                  <button type="submit" class="btn btn-success btn-sm">Aprobar</button>
+                </form>
+                <div class="w-100">
+                  <button class="btn btn-outline-danger btn-sm w-100" type="button" data-bs-toggle="collapse" data-bs-target="#rechazo-{{ licencia.id }}" aria-expanded="false" aria-controls="rechazo-{{ licencia.id }}">
+                    Rechazar
+                  </button>
+                  <div class="collapse mt-2" id="rechazo-{{ licencia.id }}">
+                    <form method="post" action="{{ url_for('licencias.rechazar', licencia_id=licencia.id) }}">
+                      {{ rechazo_form.csrf_token }}
+                      <label class="form-label small fw-semibold" for="motivo-rechazo-{{ licencia.id }}">Motivo (opcional)</label>
+                      <textarea class="form-control form-control-sm" id="motivo-rechazo-{{ licencia.id }}" name="motivo_rechazo" rows="3" placeholder="Motivo de rechazo"></textarea>
+                      <button type="submit" class="btn btn-danger btn-sm mt-2">Confirmar rechazo</button>
+                    </form>
+                  </div>
+                </div>
+                {% endif %}
+                {% if licencia.estado in [EstadoLicencia.SOLICITADA, EstadoLicencia.APROBADA] %}
+                <form method="post" action="{{ url_for('licencias.cancelar', licencia_id=licencia.id) }}" class="d-inline">
+                  {{ cancelar_form.csrf_token }}
+                  <button type="submit" class="btn btn-outline-warning btn-sm">Cancelar</button>
+                </form>
+                {% endif %}
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {{ render_pagination(pagination) }}
+    {% else %}
+    <p class="mb-0 text-muted">No hay solicitudes de licencia para los filtros seleccionados.</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/licencias/mias.html
+++ b/app/templates/licencias/mias.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+{% from "_form_helpers.html" import render_select, render_field %}
+{% from "_pagination.html" import render_pagination %}
+
+{% block title %}Mis licencias{% endblock %}
+{% block header_title %}Mis licencias{% endblock %}
+
+{% block content %}
+<div class="card mb-4">
+  <div class="card-body">
+    <form class="row g-3 align-items-end" method="get" action="{{ url_for('licencias.mias') }}">
+      <div class="col-12 col-md-3">
+        {{ render_select(form.estado, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
+      </div>
+      <div class="col-12 col-md-3">
+        {{ render_select(form.tipo, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
+      </div>
+      <div class="col-6 col-md-2">
+        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+      </div>
+      <div class="col-6 col-md-2">
+        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+      </div>
+      <div class="col-12 col-md-2 d-flex gap-2">
+        {{ form.submit(class_='btn btn-primary btn-sm flex-grow-1') }}
+        <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('licencias.mias') }}">Limpiar</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    {% if pagination.items %}
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th scope="col">Tipo</th>
+            <th scope="col">Período</th>
+            <th scope="col">Hospital</th>
+            <th scope="col">Estado</th>
+            <th scope="col">Detalle</th>
+            <th scope="col" class="text-end">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for licencia in pagination.items %}
+          <tr>
+            <td class="fw-semibold">{{ normalize_enum_value(licencia.tipo) }}</td>
+            <td>
+              <div>{{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} – {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</div>
+              <div class="text-muted small">{{ licencia.dias_habiles() }} días hábiles</div>
+            </td>
+            <td>{{ licencia.hospital.nombre if licencia.hospital else '—' }}</td>
+            <td>
+              <span class="badge bg-{{ badge_for(licencia.estado) }}">{{ normalize_enum_value(licencia.estado) }}</span>
+            </td>
+            <td class="text-wrap">
+              <div class="small text-muted">Motivo</div>
+              <div>{{ licencia.motivo }}</div>
+              {% if licencia.motivo_rechazo %}
+              <div class="small text-muted mt-2">Motivo de rechazo</div>
+              <div class="text-danger">{{ licencia.motivo_rechazo }}</div>
+              {% endif %}
+              {% if licencia.decisor %}
+              <div class="small text-muted mt-2">Decidido por {{ licencia.decisor.nombre }}{% if licencia.decidido_en %} el {{ licencia.decidido_en.strftime('%d/%m/%Y %H:%M') }}{% endif %}</div>
+              {% endif %}
+            </td>
+            <td class="text-end">
+              {% if licencia.estado == EstadoLicencia.SOLICITADA %}
+              <form method="post" action="{{ url_for('licencias.cancelar', licencia_id=licencia.id) }}" class="d-inline">
+                {{ cancel_form.csrf_token }}
+                <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('¿Cancelar la solicitud?');">Cancelar</button>
+              </form>
+              {% elif licencia.estado == EstadoLicencia.CANCELADA %}
+              <span class="text-muted">Sin acciones</span>
+              {% else %}
+              <span class="text-muted">Sin acciones</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {{ render_pagination(pagination) }}
+    {% else %}
+    <p class="mb-0 text-muted">Aún no registraste solicitudes de licencia.</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/licencias/nueva.html
+++ b/app/templates/licencias/nueva.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from "_form_helpers.html" import render_select, render_field, render_textarea %}
+
+{% block title %}Nueva licencia{% endblock %}
+{% block header_title %}Solicitar licencia{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8 col-xl-7">
+    <div class="card">
+      <div class="card-body">
+        <form method="post" action="{{ url_for('licencias.nueva') }}" novalidate>
+          {{ form.hidden_tag() }}
+          {{ render_select(form.tipo, label_class='form-label fw-semibold', input_class='form-select') }}
+          <div class="row g-3">
+            <div class="col-sm-6">
+              {{ render_field(form.fecha_inicio, label_class='form-label fw-semibold', input_class='form-control', input_type='date') }}
+            </div>
+            <div class="col-sm-6">
+              {{ render_field(form.fecha_fin, label_class='form-label fw-semibold', input_class='form-control', input_type='date') }}
+            </div>
+          </div>
+          {{ render_select(form.hospital_id, label_class='form-label fw-semibold', input_class='form-select') }}
+          {{ render_textarea(form.motivo, label_class='form-label fw-semibold', rows=4) }}
+          <div class="d-flex justify-content-end gap-2">
+            <a class="btn btn-outline-secondary" href="{{ url_for('licencias.mias') }}">Cancelar</a>
+            {{ form.submit(class_='btn btn-primary') }}
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/migrations/versions/e1d3f9c5c1d5_add_theme_pref_and_rejection_reason.py
+++ b/migrations/versions/e1d3f9c5c1d5_add_theme_pref_and_rejection_reason.py
@@ -1,0 +1,40 @@
+"""Add user theme preference and rejection reason for licenses."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "e1d3f9c5c1d5"
+down_revision = "d2f6f3b4a1c9"
+branch_labels = None
+depends_on = None
+
+
+theme_enum = sa.Enum("light", "dark", "system", name="theme_preference")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    theme_enum.create(bind, checkfirst=True)
+
+    op.add_column(
+        "usuarios",
+        sa.Column(
+            "theme_pref",
+            theme_enum,
+            nullable=False,
+            server_default="system",
+        ),
+    )
+
+    op.add_column("licencias", sa.Column("motivo_rechazo", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("licencias", "motivo_rechazo")
+
+    op.drop_column("usuarios", "theme_pref")
+
+    bind = op.get_bind()
+    theme_enum.drop(bind, checkfirst=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,3 @@
-"""Authentication flow tests."""
-from __future__ import annotations
-
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -27,21 +24,21 @@ def test_login_failure(client, superadmin_credentials):
 
 
 def test_login_redirect_contains_next_when_protected_view_accessed(client):
-    resp = client.get("/licencias/listar")
+    resp = client.get("/licencias/gestion")
     assert resp.status_code == 302
     parsed = urlparse(resp.headers["Location"])
     assert parsed.path == "/auth/login"
     query = parse_qs(parsed.query)
-    assert query.get("next") == ["/licencias/listar"]
+    assert query.get("next") == ["/licencias/gestion"]
 
 
 def test_logout_flow(client, superadmin_credentials):
-    resp = client.get("/licencias/listar")
+    resp = client.get("/licencias/gestion")
     assert resp.status_code == 302
     assert "/auth/login" in resp.headers["Location"]
 
     login(client, **superadmin_credentials)
-    resp = client.get("/licencias/listar")
+    resp = client.get("/licencias/gestion")
     assert resp.status_code == 200
 
     resp = client.get("/auth/logout", follow_redirects=False)

--- a/tests/test_licencias_views.py
+++ b/tests/test_licencias_views.py
@@ -10,35 +10,45 @@ def login(client, username: str, password: str):
     )
 
 
-def test_listar_requires_authentication(client):
-    resp = client.get("/licencias/listar")
+def test_mias_requires_authentication(client):
+    resp = client.get("/licencias/mias")
     assert resp.status_code == 302
     assert "/auth/login" in resp.headers["Location"]
 
 
-def test_listar_forbidden_without_permission(client, gestor_credentials):
-    login(client, **gestor_credentials)
-    resp = client.get("/licencias/listar")
+def test_mias_forbidden_for_superadmin(client, superadmin_credentials):
+    login(client, **superadmin_credentials)
+    resp = client.get("/licencias/mias")
     assert resp.status_code == 403
-    page = resp.get_data(as_text=True)
-    assert "Permiso denegado" in page
 
 
-def test_listar_accessible_with_permission(client, admin_credentials):
+def test_mias_accessible_for_admin(client, admin_credentials):
     login(client, **admin_credentials)
-    resp = client.get("/licencias/listar")
+    resp = client.get("/licencias/mias")
     assert resp.status_code == 200
 
 
 def test_superadmin_cannot_request_license(client, superadmin_credentials):
     login(client, **superadmin_credentials)
-    resp = client.get("/licencias/solicitar")
+    resp = client.get("/licencias/nueva")
     assert resp.status_code == 403
 
 
 def test_superadmin_post_license_forbidden(client, superadmin_credentials):
     login(client, **superadmin_credentials)
-    resp = client.post("/licencias/solicitar", data={"tipo": "temporal"})
+    resp = client.post("/licencias/nueva", data={"tipo": "vacaciones"})
+    assert resp.status_code == 403
+
+
+def test_gestion_accessible_for_superadmin(client, superadmin_credentials):
+    login(client, **superadmin_credentials)
+    resp = client.get("/licencias/gestion")
+    assert resp.status_code == 200
+
+
+def test_gestion_forbidden_for_admin(client, admin_credentials):
+    login(client, **admin_credentials)
+    resp = client.get("/licencias/gestion")
     assert resp.status_code == 403
 
 
@@ -49,7 +59,6 @@ def test_aprobar_requires_csrf_token_when_enabled(app, client, superadmin_creden
     try:
         resp = client.post(
             f"/licencias/{licencia_id}/aprobar",
-            data={"accion": "aprobar", "comentario": ""},
             follow_redirects=False,
         )
     finally:


### PR DESCRIPTION
## Summary
- add technician/admin license request listing, creation form and superadmin management board with new templates, filters and actions
- persist a user theme preference, expose a dropdown theme switcher and apply the chosen Bootstrap color mode
- expose JSON APIs for personal and administrative license views and record rejection reasons in the data model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d518c5bc9c8324aca4ebebda887578