### PR TITLE
Implement scoped dashboards and role-aware navigation

### DIFF
--- a/app/routes/api/dashboard.py
+++ b/app/routes/api/dashboard.py
@@ -1,8 +1,12 @@
 """API endpoints serving dashboard metrics."""
 from __future__ import annotations
 
-from flask import jsonify
-from flask_login import login_required
+import json
+import time
+from typing import Iterator
+
+from flask import Response, current_app, jsonify, stream_with_context
+from flask_login import current_user, login_required
 
 from app.services.dashboard_service import collect_dashboard_metrics
 
@@ -14,8 +18,28 @@ from . import api_bp
 def dashboard_metrics():
     """Return aggregated metrics for the realtime dashboard."""
 
-    payload = collect_dashboard_metrics()
+    payload = collect_dashboard_metrics(current_user)
     return jsonify(payload)
 
 
-__all__ = ["dashboard_metrics"]
+@api_bp.route("/dashboard/stream")
+@login_required
+def dashboard_stream() -> Response:
+    """Stream dashboard updates using Server Sent Events."""
+
+    user = current_user._get_current_object()
+    interval = current_app.config.get("DASHBOARD_STREAM_INTERVAL", 30)
+    retry = current_app.config.get("DASHBOARD_STREAM_RETRY", interval * 1000)
+
+    @stream_with_context
+    def generate() -> Iterator[str]:
+        yield f"retry: {retry}\n\n"
+        while True:
+            payload = collect_dashboard_metrics(user)
+            yield f"data: {json.dumps(payload)}\n\n"
+            time.sleep(max(1, int(interval)))
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+__all__ = ["dashboard_metrics", "dashboard_stream"]

--- a/app/services/dashboard_service.py
+++ b/app/services/dashboard_service.py
@@ -1,9 +1,10 @@
 """Helpers to build dashboard metrics payloads."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.sql import false
 
 from app.extensions import db
 from app.models import (
@@ -14,90 +15,232 @@ from app.models import (
     Insumo,
     Licencia,
     TipoEquipo,
+    Usuario,
+    equipo_insumos,
 )
+from app.utils.scope import ScopeValue, get_user_hospital_scope
 
 
 def _to_title(value: str) -> str:
     return value.replace("_", " ").title()
 
 
-def collect_dashboard_metrics() -> dict[str, object]:
-    """Assemble counts and chart payloads for the dashboard."""
+def _apply_scope(query, column, scope: ScopeValue):
+    if scope == "todos":
+        return query
+    if not scope:
+        return query.filter(false())
+    return query.filter(column.in_(scope))
+
+
+def _insumo_scope_filter(scope: ScopeValue):
+    if scope == "todos":
+        return None
+    if not scope:
+        return false()
+    associated = (
+        select(1)
+        .select_from(equipo_insumos.join(Equipo, equipo_insumos.c.equipo_id == Equipo.id))
+        .where(
+            equipo_insumos.c.insumo_id == Insumo.id,
+            Equipo.hospital_id.in_(scope),
+        )
+        .exists()
+    )
+    any_association = (
+        select(1)
+        .select_from(equipo_insumos)
+        .where(equipo_insumos.c.insumo_id == Insumo.id)
+        .exists()
+    )
+    return or_(associated, ~any_association)
+
+
+def _apply_license_scope(query, scope: ScopeValue, *, joined: bool = False):
+    if scope == "todos":
+        return query
+    if not scope:
+        return query.filter(false())
+    if not joined:
+        query = query.join(Usuario, Usuario.id == Licencia.user_id)
+    return query.filter(
+        or_(
+            Licencia.hospital_id.in_(scope),
+            and_(
+                Licencia.hospital_id.is_(None),
+                Usuario.hospital_id.in_(scope),
+            ),
+        )
+    )
+
+
+def _build_scope_info(scope: ScopeValue) -> dict[str, object]:
+    if scope == "todos":
+        return {"type": "todos", "hospitales": [], "summary": "Todos los hospitales"}
+    if not scope:
+        return {"type": "limitado", "hospitales": [], "summary": "Sin hospitales asignados"}
+    hospitales = (
+        db.session.query(Hospital.id, Hospital.nombre)
+        .filter(Hospital.id.in_(scope))
+        .order_by(Hospital.nombre)
+        .all()
+    )
+    data = [
+        {"id": hospital_id, "nombre": nombre}
+        for hospital_id, nombre in hospitales
+    ]
+    summary = ", ".join(item["nombre"] for item in data) if data else "Sin hospitales asignados"
+    return {"type": "limitado", "hospitales": data, "summary": summary}
+
+
+def _format_date(value: date | None) -> str:
+    if not value:
+        return "—"
+    return value.strftime("%d/%m/%Y")
+
+
+def collect_dashboard_metrics(user, top_supplies: int = 8) -> dict[str, object]:
+    """Assemble counts and chart payloads for the dashboard respecting scope."""
 
     now = datetime.utcnow()
     since = now - timedelta(days=7)
+    today = now.date()
+    yesterday = today - timedelta(days=1)
 
-    equipos_total = db.session.query(func.count(Equipo.id)).scalar() or 0
-    equipos_delta = (
-        db.session.query(func.count(Equipo.id))
-        .filter(Equipo.created_at >= since)
-        .scalar()
-        or 0
-    )
+    scope = get_user_hospital_scope(user)
+    scope_info = _build_scope_info(scope)
 
-    insumos_total = db.session.query(func.count(Insumo.id)).scalar() or 0
-    insumos_delta = (
-        db.session.query(func.count(Insumo.id))
-        .filter(Insumo.created_at >= since)
-        .scalar()
-        or 0
-    )
+    equipos_total_query = _apply_scope(db.session.query(func.count(Equipo.id)), Equipo.hospital_id, scope)
+    equipos_total = equipos_total_query.scalar() or 0
 
-    hospitales_total = db.session.query(func.count(Hospital.id)).scalar() or 0
-    hospitales_delta = (
-        db.session.query(func.count(Hospital.id))
-        .filter(Hospital.created_at >= since)
-        .scalar()
-        or 0
+    equipos_delta_query = _apply_scope(
+        db.session.query(func.count(Equipo.id)).filter(Equipo.created_at >= since),
+        Equipo.hospital_id,
+        scope,
     )
+    equipos_delta = equipos_delta_query.scalar() or 0
 
-    licencias_pendientes = (
-        db.session.query(func.count(Licencia.id))
-        .filter(Licencia.estado == EstadoLicencia.SOLICITADA)
-        .scalar()
-        or 0
+    insumo_filter = _insumo_scope_filter(scope)
+    insumo_base = db.session.query(func.count(func.distinct(Insumo.id)))
+    if insumo_filter is not None:
+        insumo_base = insumo_base.filter(insumo_filter)
+    insumos_total = insumo_base.scalar() or 0
+
+    insumo_delta = db.session.query(func.count(func.distinct(Insumo.id))).filter(Insumo.created_at >= since)
+    if insumo_filter is not None:
+        insumo_delta = insumo_delta.filter(insumo_filter)
+    insumos_delta_value = insumo_delta.scalar() or 0
+
+    hospitales_query = db.session.query(func.count(Hospital.id))
+    if scope != "todos":
+        if not scope:
+            hospitales_total = 0
+        else:
+            hospitales_total = hospitales_query.filter(Hospital.id.in_(scope)).scalar() or 0
+    else:
+        hospitales_total = hospitales_query.scalar() or 0
+
+    hospitales_delta_query = db.session.query(func.count(Hospital.id)).filter(Hospital.created_at >= since)
+    if scope != "todos":
+        if not scope:
+            hospitales_delta = 0
+        else:
+            hospitales_delta = hospitales_delta_query.filter(Hospital.id.in_(scope)).scalar() or 0
+    else:
+        hospitales_delta = hospitales_delta_query.scalar() or 0
+
+    licencias_pendientes_query = db.session.query(func.count(Licencia.id)).filter(
+        Licencia.estado == EstadoLicencia.SOLICITADA
     )
-    licencias_delta = (
-        db.session.query(func.count(Licencia.id))
-        .filter(
-            Licencia.estado == EstadoLicencia.SOLICITADA,
-            Licencia.created_at >= since,
-        )
-        .scalar()
-        or 0
+    licencias_pendientes_query = _apply_license_scope(licencias_pendientes_query, scope)
+    licencias_pendientes = licencias_pendientes_query.scalar() or 0
+
+    licencias_delta_query = db.session.query(func.count(Licencia.id)).filter(
+        Licencia.estado == EstadoLicencia.SOLICITADA,
+        Licencia.created_at >= since,
     )
+    licencias_delta_query = _apply_license_scope(licencias_delta_query, scope)
+    licencias_delta = licencias_delta_query.scalar() or 0
+
+    # Licencias activas hoy
+    licencias_hoy_query = db.session.query(
+        Licencia.id,
+        Licencia.tipo,
+        Licencia.fecha_fin,
+        Usuario.nombre,
+        Usuario.apellido,
+        Hospital.nombre,
+    ).join(Usuario, Usuario.id == Licencia.user_id)
+    licencias_hoy_query = licencias_hoy_query.outerjoin(Hospital, Hospital.id == Licencia.hospital_id)
+    licencias_hoy_query = licencias_hoy_query.filter(
+        Licencia.estado == EstadoLicencia.APROBADA,
+        Licencia.fecha_inicio <= today,
+        Licencia.fecha_fin >= today,
+    )
+    licencias_hoy_query = _apply_license_scope(licencias_hoy_query, scope, joined=True)
+    licencias_hoy_rows = licencias_hoy_query.order_by(Usuario.nombre, Usuario.apellido).all()
+    licencias_hoy = [
+        {
+            "id": licencia_id,
+            "nombre": f"{nombre} {apellido}".strip(),
+            "hospital": hospital_nombre or "Sin hospital",
+            "hasta": _format_date(fecha_fin),
+            "tipo": _to_title(tipo.value if hasattr(tipo, "value") else str(tipo)),
+        }
+        for licencia_id, tipo, fecha_fin, nombre, apellido, hospital_nombre in licencias_hoy_rows
+    ]
+
+    licencias_hoy_total = len(licencias_hoy)
+    licencias_ayer_query = db.session.query(func.count(Licencia.id)).filter(
+        Licencia.estado == EstadoLicencia.APROBADA,
+        Licencia.fecha_inicio <= yesterday,
+        Licencia.fecha_fin >= yesterday,
+    )
+    licencias_ayer_query = _apply_license_scope(licencias_ayer_query, scope)
+    licencias_ayer_total = licencias_ayer_query.scalar() or 0
+
+    licenses_today_payload = {
+        "total": licencias_hoy_total,
+        "delta": licencias_hoy_total - int(licencias_ayer_total),
+        "items": licencias_hoy,
+    }
 
     # Equipos por estado
-    equipment_state_rows = (
-        db.session.query(Equipo.estado, func.count(Equipo.id))
-        .group_by(Equipo.estado)
-        .all()
-    )
+    equipment_state_query = db.session.query(Equipo.estado, func.count(Equipo.id)).group_by(Equipo.estado)
+    equipment_state_query = _apply_scope(equipment_state_query, Equipo.hospital_id, scope)
+    equipment_state_rows = equipment_state_query.all()
     equipment_state = {
-        "labels": [_to_title(row[0].value if isinstance(row[0], EstadoEquipo) else str(row[0])) for row in equipment_state_rows],
+        "labels": [
+            _to_title(row[0].value if isinstance(row[0], EstadoEquipo) else str(row[0]))
+            for row in equipment_state_rows
+        ],
         "values": [row[1] for row in equipment_state_rows],
     }
 
     # Equipos por tipo (top 7)
+    equipment_type_total = func.count(Equipo.id).label("total")
+    equipment_type_query = db.session.query(Equipo.tipo, equipment_type_total).group_by(Equipo.tipo)
+    equipment_type_query = _apply_scope(equipment_type_query, Equipo.hospital_id, scope)
     equipment_type_rows = (
-        db.session.query(Equipo.tipo, func.count(Equipo.id).label("total"))
-        .group_by(Equipo.tipo)
-        .order_by(func.count(Equipo.id).desc())
-        .limit(7)
-        .all()
+        equipment_type_query.order_by(equipment_type_total.desc()).limit(7).all()
     )
     equipment_type = {
-        "labels": [_to_title(row[0].value if isinstance(row[0], TipoEquipo) else str(row[0])) for row in equipment_type_rows],
+        "labels": [
+            _to_title(row[0].value if isinstance(row[0], TipoEquipo) else str(row[0]))
+            for row in equipment_type_rows
+        ],
         "values": [row[1] for row in equipment_type_rows],
     }
 
     # Stock de insumos por unidad/categoría
+    insumo_stock_query = db.session.query(
+        func.coalesce(Insumo.unidad_medida, "Sin unidad"),
+        func.sum(Insumo.stock),
+    )
+    if insumo_filter is not None:
+        insumo_stock_query = insumo_stock_query.filter(insumo_filter)
     insumo_stock_rows = (
-        db.session.query(
-            func.coalesce(Insumo.unidad_medida, "Sin unidad"),
-            func.sum(Insumo.stock),
-        )
-        .group_by(Insumo.unidad_medida)
+        insumo_stock_query.group_by(Insumo.unidad_medida)
         .order_by(func.sum(Insumo.stock).desc())
         .limit(7)
         .all()
@@ -107,22 +250,29 @@ def collect_dashboard_metrics() -> dict[str, object]:
         "values": [int(row[1] or 0) for row in insumo_stock_rows],
     }
 
-    faltante = (Insumo.stock_minimo - Insumo.stock).label("faltante")
-    critical_query = (
-        db.session.query(Insumo, faltante)
-        .filter(Insumo.stock_minimo > 0, Insumo.stock <= Insumo.stock_minimo)
-        .order_by(faltante.desc(), Insumo.nombre)
-        .limit(8)
-    )
+    critical_query = db.session.query(Insumo)
+    if insumo_filter is not None:
+        critical_query = critical_query.filter(insumo_filter)
+    critical_items = [
+        (
+            insumo,
+            max(int(insumo.stock_minimo or 0) - int(insumo.stock or 0), 0),
+        )
+        for insumo in critical_query.filter(
+            Insumo.stock_minimo > 0,
+            Insumo.stock <= Insumo.stock_minimo,
+        ).all()
+    ]
+    critical_items.sort(key=lambda item: (-item[1], item[0].nombre))
     critical_supplies = [
         {
             "id": insumo.id,
             "nombre": insumo.nombre,
             "stock": int(insumo.stock or 0),
             "stock_minimo": int(insumo.stock_minimo or 0),
-            "faltante": int(max(falta, 0)),
+            "faltante": int(faltante),
         }
-        for insumo, falta in critical_query
+        for insumo, faltante in critical_items[:top_supplies]
     ]
 
     return {
@@ -139,7 +289,7 @@ def collect_dashboard_metrics() -> dict[str, object]:
                 "key": "insumos",
                 "label": "Insumos",
                 "value": int(insumos_total),
-                "delta": int(insumos_delta),
+                "delta": int(insumos_delta_value),
             },
             {
                 "key": "hospitales",
@@ -148,7 +298,13 @@ def collect_dashboard_metrics() -> dict[str, object]:
                 "delta": int(hospitales_delta),
             },
             {
-                "key": "licencias",
+                "key": "licencias_hoy",
+                "label": "Licencias hoy",
+                "value": int(licenses_today_payload["total"]),
+                "delta": int(licenses_today_payload["delta"]),
+            },
+            {
+                "key": "licencias_pendientes",
                 "label": "Licencias pendientes",
                 "value": int(licencias_pendientes),
                 "delta": int(licencias_delta),
@@ -160,7 +316,23 @@ def collect_dashboard_metrics() -> dict[str, object]:
             "insumo_stock": insumo_stock,
         },
         "critical_supplies": critical_supplies,
+        "licenses_today": licenses_today_payload,
+        "scope": scope_info,
     }
 
 
-__all__ = ["collect_dashboard_metrics"]
+def collect_license_history(user) -> dict[str, list[int] | list[str]]:
+    """Return aggregated license approvals per month respecting scope."""
+
+    scope = get_user_hospital_scope(user)
+    query = db.session.query(Licencia.fecha_inicio).filter(Licencia.estado == EstadoLicencia.APROBADA)
+    query = _apply_license_scope(query, scope)
+    counts: dict[str, int] = {}
+    for (fecha_inicio,) in query.all():
+        key = fecha_inicio.strftime("%Y-%m")
+        counts[key] = counts.get(key, 0) + 1
+    labels = sorted(counts.keys())
+    return {"labels": labels, "values": [counts[label] for label in labels]}
+
+
+__all__ = ["collect_dashboard_metrics", "collect_license_history"]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -269,6 +269,10 @@ body {
   color: var(--color-success);
 }
 
+.kpi-variation--down {
+  color: var(--color-danger);
+}
+
 .kpi-variation--steady {
   color: var(--color-muted);
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
         {% set usuarios_open = current_bp in ['usuarios', 'licencias', 'permisos'] %}
         {% set vista_actual = request.args.get('vista', 'hospitales') %}
         {% set filtro_insumos = request.args.get('criticos') %}
-        {% if has_role('superadmin') %}
+        {% if has_role('superadmin', 'admin') %}
         {% set licencias_url = url_for('licencias.gestion') %}
         {% else %}
         {% set licencias_url = url_for('licencias.mias') %}
@@ -78,11 +78,14 @@
                   <ul class="sidebar-subnav list-unstyled mb-0">
                     <li><a class="sidebar-sublink{% if current_bp == 'insumos' and not filtro_insumos %} active{% endif %}" href="{{ url_for('insumos.listar') }}">Listado</a></li>
                     <li><a class="sidebar-sublink{% if current_bp == 'insumos' and filtro_insumos %} active{% endif %}" href="{{ url_for('insumos.listar', criticos=1) }}">Críticos</a></li>
+                    {% if current_user.has_permission('insumos:write') %}
                     <li><a class="sidebar-sublink{% if current_endpoint == 'insumos.crear' %} active{% endif %}" href="{{ url_for('insumos.crear') }}">Nuevo</a></li>
+                    {% endif %}
                   </ul>
                 </div>
               </div>
             </div>
+            {% if has_role('admin', 'superadmin') %}
             <div class="accordion-item">
               <h2 class="accordion-header" id="accordionUbicaciones">
                 <button class="accordion-button{% if not ubicaciones_open %} collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUbicaciones" aria-expanded="{{ 'true' if ubicaciones_open else 'false' }}" aria-controls="collapseUbicaciones">
@@ -99,7 +102,6 @@
                 </div>
               </div>
             </div>
-            {% if has_role('admin', 'superadmin') %}
             <div class="accordion-item">
               <h2 class="accordion-header" id="accordionUsuarios">
                 <button class="accordion-button{% if not usuarios_open %} collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUsuarios" aria-expanded="{{ 'true' if usuarios_open else 'false' }}" aria-controls="collapseUsuarios">
@@ -111,11 +113,9 @@
                   <ul class="sidebar-subnav list-unstyled mb-0">
                     <li><a class="sidebar-sublink{% if current_bp == 'usuarios' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('usuarios.listar') }}">Listado</a></li>
                     <li><a class="sidebar-sublink{% if current_endpoint == 'usuarios.crear' %} active{% endif %}" href="{{ url_for('usuarios.crear') }}">Nuevo usuario</a></li>
-                    <li><a class="sidebar-sublink{% if current_bp == 'licencias' %} active{% endif %}" href="{{ licencias_url }}">Licencias</a></li>
-                    {% if has_role('superadmin') %}
                     <li><a class="sidebar-sublink{% if current_bp == 'permisos' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('permisos.listar') }}">Permisos</a></li>
-                    {% endif %}
                     <li><a class="sidebar-sublink{% if current_bp == 'permisos' and 'auditorias' in current_endpoint %} active{% endif %}" href="{{ url_for('permisos.listar') }}">Auditorías</a></li>
+                    <li><a class="sidebar-sublink{% if current_bp == 'licencias' %} active{% endif %}" href="{{ url_for('licencias.gestion') }}">Licencias (gestión)</a></li>
                   </ul>
                 </div>
               </div>

--- a/app/templates/main/_dashboard_common.html
+++ b/app/templates/main/_dashboard_common.html
@@ -1,0 +1,120 @@
+<div class="dashboard-updated text-muted small mb-3" data-dashboard-updated>
+  Actualizado: <span data-dashboard-updated-label>{{ metrics.generated_at_display }}</span>
+  {% if show_dashboard_link %}
+  <span class="ms-2"><a class="link-secondary" href="{{ url_for('main.dashboard') }}">Ver dashboard completo</a></span>
+  {% elif show_home_link %}
+  <span class="ms-2"><a class="link-secondary" href="{{ url_for('main.index') }}">Volver al inicio</a></span>
+  {% endif %}
+</div>
+
+{% if metrics.scope %}
+  <div class="alert alert-info" role="status">
+    {% if metrics.scope.type == 'todos' %}
+      Visualizando datos de todos los hospitales.
+    {% elif metrics.scope.hospitales %}
+      Visualizando datos de: {{ metrics.scope.summary }}.
+    {% else %}
+      No hay hospitales asignados para su usuario.
+    {% endif %}
+  </div>
+{% endif %}
+
+<div class="row g-3" data-dashboard-kpis>
+  {% for kpi in metrics.kpis %}
+  <div class="col-12 col-sm-6 col-lg-3">
+    <div class="card kpi-card" data-kpi-card="{{ kpi.key }}">
+      <div class="card-body">
+        <span class="text-muted text-uppercase small">{{ kpi.label }}</span>
+        <div class="display-6 fw-bold" data-kpi-value>{{ kpi.value }}</div>
+        <div class="kpi-variation{% if kpi.delta > 0 %} kpi-variation--up{% elif kpi.delta < 0 %} kpi-variation--down{% else %} kpi-variation--steady{% endif %}" data-kpi-variation>
+          <span class="kpi-trend-icon">
+            {% if kpi.delta > 0 %}▲{% elif kpi.delta < 0 %}▼{% else %}→{% endif %}
+          </span>
+          <span class="kpi-trend-value">
+            {% if kpi.delta > 0 %}+{{ kpi.delta }}{% elif kpi.delta < 0 %}{{ kpi.delta }}{% else %}0{% endif %}
+          </span>
+          <span class="text-muted">últimos 7 días{% if kpi.key == 'licencias_hoy' %} / variación diaria{% endif %}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<div class="row g-3 mt-1">
+  <div class="col-lg-6">
+    <div class="card h-100">
+      <div class="card-header">Distribución de equipos por estado</div>
+      <div class="card-body">
+        <canvas id="chartEquipmentState" height="220" aria-label="Gráfico de equipos por estado" role="img"></canvas>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card h-100">
+      <div class="card-header">Equipos por tipo</div>
+      <div class="card-body">
+        <canvas id="chartEquipmentType" height="220" aria-label="Gráfico de equipos por tipo" role="img"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row g-3 mt-1">
+  <div class="col-lg-7">
+    <div class="card h-100">
+      <div class="card-header">Stock de insumos por categoría</div>
+      <div class="card-body">
+        <canvas id="chartInsumoStock" height="220" aria-label="Gráfico de stock de insumos" role="img"></canvas>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-5 d-flex flex-column gap-3">
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Alertas de stock crítico</span>
+        <span class="badge bg-danger-subtle text-danger-emphasis" data-critical-total>{{ metrics.critical_supplies|length }}</span>
+      </div>
+      <div class="card-body">
+        <ul class="list-group list-group-flush" data-critical-list>
+          {% for item in metrics.critical_supplies %}
+          <li class="list-group-item d-flex justify-content-between align-items-start">
+            <div>
+              <div class="fw-semibold">{{ item.nombre }}</div>
+              <div class="text-muted small">Mínimo {{ item.stock_minimo }} · Faltan {{ item.faltante }}</div>
+            </div>
+            <span class="status-badge status-badge--danger">{{ item.stock }}</span>
+          </li>
+          {% else %}
+          <li class="list-group-item text-muted">Sin insumos en alerta.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Personas en licencia hoy</span>
+        <span class="badge bg-primary-subtle text-primary-emphasis" data-licenses-total>{{ metrics.licenses_today.total }}</span>
+      </div>
+      <div class="card-body">
+        <ul class="list-group list-group-flush" data-licenses-list>
+          {% for item in metrics.licenses_today['items'] %}
+          <li class="list-group-item">
+            <div class="fw-semibold">{{ item.nombre }}</div>
+            <div class="text-muted small">{{ item.hospital }} · hasta {{ item.hasta }} · {{ item.tipo }}</div>
+          </li>
+          {% else %}
+          <li class="list-group-item text-muted">Sin licencias registradas para hoy.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card mt-3">
+  <div class="card-header">Licencias aprobadas por mes</div>
+  <div class="card-body">
+    <canvas id="licenseChart" height="220" aria-label="Gráfico de licencias aprobadas" role="img"></canvas>
+  </div>
+</div>

--- a/app/templates/main/dashboard_admin.html
+++ b/app/templates/main/dashboard_admin.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}Inicio{% endblock %}
+{% block title %}Dashboard{% endblock %}
+{% block header_title %}Dashboard administrativo{% endblock %}
+{% block header_subtitle %}
+<span class="text-muted">Hospitales asignados: {{ metrics.scope.summary }}</span>
+{% endblock %}
 {% block content %}
-  {% with show_dashboard_link=true %}
+  {% with show_home_link=true %}
     {% include 'main/_dashboard_common.html' %}
   {% endwith %}
 {% endblock %}

--- a/app/templates/main/dashboard_superadmin.html
+++ b/app/templates/main/dashboard_superadmin.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}Inicio{% endblock %}
+{% block title %}Dashboard{% endblock %}
+{% block header_title %}Dashboard general{% endblock %}
+{% block header_subtitle %}
+<span class="text-muted">Acceso completo a {{ metrics.scope.summary }}</span>
+{% endblock %}
 {% block content %}
-  {% with show_dashboard_link=true %}
+  {% with show_home_link=true %}
     {% include 'main/_dashboard_common.html' %}
   {% endwith %}
 {% endblock %}

--- a/app/templates/main/dashboard_tecnico.html
+++ b/app/templates/main/dashboard_tecnico.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}Inicio{% endblock %}
+{% block title %}Dashboard{% endblock %}
+{% block header_title %}Dashboard técnico{% endblock %}
+{% block header_subtitle %}
+<span class="text-muted">Datos visibles para: {{ metrics.scope.summary }}</span>
+{% endblock %}
 {% block content %}
-  {% with show_dashboard_link=true %}
+  {% with show_home_link=true %}
     {% include 'main/_dashboard_common.html' %}
   {% endwith %}
 {% endblock %}

--- a/app/utils/scope.py
+++ b/app/utils/scope.py
@@ -1,0 +1,38 @@
+"""Helpers for computing hospital scope restrictions per user."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from flask_login import AnonymousUserMixin
+
+from app.models import Usuario
+
+
+ScopeValue = list[int] | str
+
+
+def _normalize_ids(values: Iterable[int]) -> list[int]:
+    return sorted({int(value) for value in values})
+
+
+def get_user_hospital_scope(user: Usuario | AnonymousUserMixin | None) -> ScopeValue:
+    """Return the hospital IDs a ``user`` can access or ``"todos"``."""
+
+    if user is None or not getattr(user, "is_authenticated", False):
+        return []
+
+    role = (getattr(user, "role", None) or "").lower()
+    if role == "superadmin":
+        return "todos"
+
+    allowed = set()
+    if hasattr(user, "allowed_hospital_ids"):
+        allowed.update(user.allowed_hospital_ids(None))
+
+    if getattr(user, "hospital_id", None):
+        allowed.add(int(user.hospital_id))
+
+    return _normalize_ids(allowed)
+
+
+__all__ = ["get_user_hospital_scope", "ScopeValue"]


### PR DESCRIPTION
## Summary
- scope dashboard metrics by hospital permissions, add license insights, and expose an SSE endpoint
- introduce role-specific dashboard templates with shared content partial and updated UI scripts/styles
- adjust sidebar navigation to respect role permissions and hide restricted sections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d51f3bd55c83249addd694df7361e2