### PR TITLE
Add technician fixtures to permissions tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,8 @@ def _populate_database() -> dict[str, object]:
     rol_admin = Rol(nombre="admin")
     rol_gestor = Rol(nombre="gestor")
     rol_visor = Rol(nombre="visor")
-    db.session.add_all([rol_super, rol_admin, rol_gestor, rol_visor])
+    rol_tecnico = Rol(nombre="tecnico")
+    db.session.add_all([rol_super, rol_admin, rol_gestor, rol_visor, rol_tecnico])
     db.session.flush()
 
     superadmin = Usuario(
@@ -95,11 +96,28 @@ def _populate_database() -> dict[str, object]:
     )
     visor.set_password(DEFAULT_PASSWORD)
 
-    db.session.add_all([superadmin, admin, gestor, visor])
+    tecnico = Usuario(
+        username="tecnico",
+        nombre="Teresita",
+        apellido="Tecnica",
+        dni="30000004",
+        email="tecnico@hospital.test",
+        rol=rol_tecnico,
+        hospital=hospital,
+    )
+    tecnico.set_password(DEFAULT_PASSWORD)
+
+    db.session.add_all([superadmin, admin, gestor, visor, tecnico])
     db.session.flush()
 
     permisos = [
-        Permiso(rol=rol_super, modulo=modulo, can_read=True, can_write=True)
+        Permiso(
+            rol=rol_super,
+            modulo=modulo,
+            can_read=True,
+            can_write=True,
+            allow_export=True,
+        )
         for modulo in Modulo
     ]
     permisos.append(
@@ -127,6 +145,33 @@ def _populate_database() -> dict[str, object]:
             hospital=hospital,
             can_read=True,
             can_write=True,
+        )
+    )
+    permisos.append(
+        Permiso(
+            rol=rol_tecnico,
+            modulo=Modulo.INVENTARIO,
+            hospital=hospital,
+            can_read=True,
+            can_write=True,
+        )
+    )
+    permisos.append(
+        Permiso(
+            rol=rol_tecnico,
+            modulo=Modulo.ADJUNTOS,
+            hospital=hospital,
+            can_read=True,
+            can_write=True,
+        )
+    )
+    permisos.append(
+        Permiso(
+            rol=rol_tecnico,
+            modulo=Modulo.INSUMOS,
+            hospital=hospital,
+            can_read=True,
+            can_write=False,
         )
     )
     db.session.add_all(permisos)
@@ -187,6 +232,7 @@ def _populate_database() -> dict[str, object]:
         "admin": admin,
         "gestor": gestor,
         "visor": visor,
+        "tecnico": tecnico,
         "servicio": servicio,
         "oficina": oficina,
         "equipo": equipo,
@@ -223,6 +269,7 @@ def data(app):
             "admin": Usuario.query.filter_by(username="admin").first(),
             "gestor": Usuario.query.filter_by(username="gestor").first(),
             "visor": Usuario.query.filter_by(username="visor").first(),
+            "tecnico": Usuario.query.filter_by(username="tecnico").first(),
             "equipo": Equipo.query.first(),
             "insumo": Insumo.query.first(),
             "acta": Acta.query.first(),
@@ -250,4 +297,9 @@ def gestor_credentials():
 @pytest.fixture()
 def visor_credentials():
     return {"username": "visor", "password": DEFAULT_PASSWORD}
+
+
+@pytest.fixture()
+def tecnico_credentials():
+    return {"username": "tecnico", "password": DEFAULT_PASSWORD}
 

--- a/tests/test_permisos.py
+++ b/tests/test_permisos.py
@@ -33,6 +33,17 @@ def test_admin_limitado_a_su_hospital(app, data):
         assert hospitales == {hospital_id}
 
 
+def test_tecnico_limitado_a_su_hospital(app, data):
+    tecnico_id = data["tecnico"].id
+    hospital_id = data["hospital"].id
+
+    with app.app_context():
+        tecnico = Usuario.query.get(tecnico_id)
+        assert tecnico is not None
+        hospitales = tecnico.allowed_hospital_ids(Modulo.INVENTARIO.value)
+        assert hospitales == {hospital_id}
+
+
 def test_guardar_permisos_usuario_superadmin(client, superadmin_credentials, data, app):
     login(client, **superadmin_credentials)
     admin = data["admin"]
@@ -53,10 +64,21 @@ def test_guardar_permisos_usuario_superadmin(client, superadmin_credentials, dat
         assert refreshed is not None
         perms = Permiso.query.filter_by(rol_id=refreshed.rol_id, modulo=Modulo.INVENTARIO).all()
         assert any(p.hospital_id is None and p.can_read for p in perms)
+        assert any(p.hospital_id is None and p.allow_export for p in perms)
 
 
 def test_guardar_permisos_usuario_requiere_superadmin(client, admin_credentials, data):
     login(client, **admin_credentials)
+    target = data["gestor"]
+    resp = client.post(
+        f"/permisos/usuarios/{target.id}/guardar",
+        json={"hospitals": [0], "modules": {}},
+    )
+    assert resp.status_code == 403
+
+
+def test_tecnico_no_puede_guardar_permisos(client, tecnico_credentials, data):
+    login(client, **tecnico_credentials)
     target = data["gestor"]
     resp = client.post(
         f"/permisos/usuarios/{target.id}/guardar",


### PR DESCRIPTION
## Summary
- extend the shared test fixtures with a seeded tecnico role, user, and permissions while keeping existing gestor data and DNI fields
- expose the tecnico user through the data and credential fixtures for permission tests
- expand permission tests with tecnico access expectations and stronger assertions on stored exports

## Testing
- pytest tests/test_permisos.py

------
https://chatgpt.com/codex/tasks/task_e_68d5b4c63c988324b27831e3d88dd804