### PR TITLE
fix/migrations-and-first-boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Sistema web completo y listo para producción para la gestión de inventario hos
    - [5.3 Con Docker](#53-con-docker)
    - [5.4 Makefile (atajos)](#54-makefile-atajos)
 6. Base de datos, migraciones y seeds
+   - [6.1 Primer arranque / SQLite](#61-primer-arranque--sqlite)
 7. Roles, permisos y seguridad
 8. Módulo de Licencias/Vacaciones
    - [8.1 Modelo de datos](#81-modelo-de-datos)
@@ -207,6 +208,17 @@ Seeds (`seeds/seed.py`): abre una sesión SQLAlchemy sobre `DATABASE_URL`, limpi
 - `consulta / Cambiar123!` (Usuario de solo lectura)
 - Equipos/insumos/actas/adjuntos/licencias de ejemplo
 - Asegura que los permisos por hospital y módulo queden cargados.
+
+### 6.1 Primer arranque / SQLite
+
+Para validar el sistema rápidamente sin levantar PostgreSQL podés usar SQLite apuntando `DATABASE_URL` a un archivo local (por ejemplo `sqlite:///inventario.db`). El orden recomendado es:
+
+1. **Definir la URL:** `export DATABASE_URL=sqlite:///inventario.db` (o `set` en Windows).
+2. **Crear el esquema:** `flask db upgrade` (las migraciones usan `render_as_batch` y `CheckConstraint` para soportar SQLite).
+3. **Sembrar datos básicos:** `python seeds/seed.py` (solo después del `upgrade`).
+4. **Levantar la app:** `flask run`.
+
+El `before_request` que valida licencias ahora detecta si las tablas `usuarios`/`licencias` existen antes de consultar, por lo que un `flask run` accidental antes de migrar no devuelve 500. Aun así, siempre corré las migraciones primero para garantizar que los seeds y el login funcionen.
 
 ## 7. Roles, permisos y seguridad
 

--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required, login_user, logout_user
+from sqlalchemy import inspect
 
 from app.extensions import db
 from app.forms.login import LoginForm
@@ -58,6 +59,10 @@ def logout():
 
 @auth_bp.before_app_request
 def validar_licencia():
+    engine = db.engine
+    inspector = inspect(engine)
+    if not inspector.has_table("usuarios") or not inspector.has_table("licencias"):
+        return None
     if not current_user.is_authenticated:
         return None
     if usuario_con_licencia_activa(current_user.id):

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,12 +1,15 @@
-from __future__ import with_statement
+"""Alembic configuration for the project."""
+from __future__ import annotations
 
-from logging.config import fileConfig
 import os
 import sys
+from logging.config import fileConfig
 from pathlib import Path
+from typing import Any
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection, URL
 
 # Ensure the application package is importable when Alembic runs from the
 # ``migrations`` directory.
@@ -15,15 +18,8 @@ if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - configuration hook
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from config import Config
-
-
-# Import the SQLAlchemy models so the metadata includes every table defined in
-# ``app.models``.  Alembic's autogenerate feature relies on this metadata to
-# compare the declared schema with the actual database.
 from app.models.base import Base
-
-# Importing the modules registers their tables on ``Base.metadata``.
-from app.models import (  # noqa: F401  - imported for side effects
+from app.models import (  # noqa: F401 - imported for side effects
     acta,
     adjunto,
     auditoria,
@@ -37,30 +33,37 @@ from app.models import (  # noqa: F401  - imported for side effects
     usuario,
 )
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
 if config.config_file_name is not None:  # pragma: no cover - configuration hook
     ini_path = Path(config.config_file_name)
     if ini_path.exists():
         fileConfig(config.config_file_name)
 
-# Configure the SQLAlchemy URL from the environment (if provided) or fall back
-# to the application's default database URI.
-database_url = os.getenv("DATABASE_URL", Config.SQLALCHEMY_DATABASE_URI)
-config.set_main_option("sqlalchemy.url", database_url)
 
-# Use the project's declarative ``Base`` metadata for autogeneration support.
-target_metadata = Base.metadata
+def _database_url() -> str:
+    return os.getenv("DATABASE_URL", Config.SQLALCHEMY_DATABASE_URI)
+
+
+def _common_config_kwargs(url: str | URL) -> dict[str, Any]:
+    url_str = str(url)
+    kwargs: dict[str, Any] = {
+        "target_metadata": Base.metadata,
+        "compare_type": True,
+        "compare_server_default": True,
+    }
+    if url_str.startswith("sqlite"):
+        kwargs["render_as_batch"] = True
+    return kwargs
 
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    url = _database_url()
+    config.set_main_option("sqlalchemy.url", url)
+
+    context.configure(url=url, literal_binds=True, **_common_config_kwargs(url))
 
     with context.begin_transaction():
         context.run_migrations()
@@ -68,14 +71,19 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
+
+    configuration = config.get_section(config.config_ini_section)
+    assert configuration is not None
+    configuration["sqlalchemy.url"] = _database_url()
+
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        configuration,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
 
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+    with connectable.connect() as connection:  # type: Connection
+        context.configure(connection=connection, **_common_config_kwargs(connection.engine.url))
 
         with context.begin_transaction():
             context.run_migrations()

--- a/migrations/versions/8a9f4ce0f1a7_add_apellido_to_usuarios.py
+++ b/migrations/versions/8a9f4ce0f1a7_add_apellido_to_usuarios.py
@@ -17,8 +17,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("usuarios", sa.Column("apellido", sa.String(length=120), nullable=True))
+    with op.batch_alter_table("usuarios", recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("apellido", sa.String(length=120), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("usuarios", "apellido")
+    with op.batch_alter_table("usuarios", recreate="always") as batch_op:
+        batch_op.drop_column("apellido")

--- a/migrations/versions/a4b3c2d1e0f0_tipo_equipo_catalogue.py
+++ b/migrations/versions/a4b3c2d1e0f0_tipo_equipo_catalogue.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
-# revision identifiers, used by Alembic.
 revision = "a4b3c2d1e0f0"
 down_revision = "f3c92c1f2f6d"
 branch_labels = None
@@ -26,75 +26,115 @@ DEFAULT_TYPES: list[tuple[str, str]] = [
 ]
 
 
+EQUIPO_TYPE_VALUES = tuple(slug for slug, _ in DEFAULT_TYPES)
+
+
+def _enum_values_sql(values: tuple[str, ...]) -> str:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for candidate in (value, value.upper()):
+            if candidate not in seen:
+                ordered.append(candidate)
+                seen.add(candidate)
+    return ", ".join(f"'{value}'" for value in ordered)
+
+
 def upgrade() -> None:
     op.create_table(
         "tipo_equipo",
         sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("slug", sa.String(length=80), nullable=False),
         sa.Column("nombre", sa.String(length=160), nullable=False),
         sa.Column("activo", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("slug", name="uq_tipo_equipo_slug"),
         sa.UniqueConstraint("nombre", name="uq_tipo_equipo_nombre"),
-    )
-    op.add_column("equipos", sa.Column("tipo_id", sa.Integer(), nullable=True))
-    op.create_foreign_key(
-        "fk_equipos_tipo_equipo",
-        "equipos",
-        "tipo_equipo",
-        ["tipo_id"],
-        ["id"],
     )
 
     bind = op.get_bind()
-    for slug, nombre in DEFAULT_TYPES:
-        bind.execute(
-            sa.text("INSERT INTO tipo_equipo (nombre, activo) VALUES (:nombre, true)"),
-            {"nombre": nombre},
-        )
-        bind.execute(
-            sa.text(
-                "UPDATE equipos SET tipo_id = (SELECT id FROM tipo_equipo WHERE nombre = :nombre) "
-                "WHERE tipo = :slug"
-            ),
-            {"nombre": nombre, "slug": slug},
+    inspector = inspect(bind)
+
+    with op.batch_alter_table("equipos", recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("tipo_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_equipos_tipo_equipo",
+            "tipo_equipo",
+            ["tipo_id"],
+            ["id"],
         )
 
-    # Fallback: asignar tipo "Otro" a cualquier registro sin mapeo previo
-    bind.execute(
-        sa.text(
-            "UPDATE equipos SET tipo_id = (SELECT id FROM tipo_equipo WHERE nombre = :nombre) "
-            "WHERE tipo_id IS NULL"
-        ),
-        {"nombre": "Otro"},
+    insert_stmt = sa.text(
+        "INSERT INTO tipo_equipo (slug, nombre, activo, created_at, updated_at) "
+        "VALUES (:slug, :nombre, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     )
+    for slug, nombre in DEFAULT_TYPES:
+        bind.execute(insert_stmt, {"slug": slug, "nombre": nombre})
 
-    op.alter_column("equipos", "tipo_id", existing_type=sa.Integer(), nullable=False)
-    op.drop_column("equipos", "tipo")
-    op.alter_column("tipo_equipo", "activo", existing_type=sa.Boolean(), server_default=None)
-    op.execute("DROP TYPE IF EXISTS tipo_equipo")
+    update_stmt = sa.text(
+        "UPDATE equipos SET tipo_id = (SELECT id FROM tipo_equipo WHERE slug = :slug) "
+        "WHERE tipo = :legacy"
+    )
+    for slug, _ in DEFAULT_TYPES:
+        bind.execute(update_stmt, {"slug": slug, "legacy": slug})
+
+    fallback_stmt = sa.text(
+        "UPDATE equipos SET tipo_id = (SELECT id FROM tipo_equipo WHERE slug = :slug) "
+        "WHERE tipo_id IS NULL"
+    )
+    bind.execute(fallback_stmt, {"slug": "otro"})
+
+    constraints = {c["name"] for c in inspector.get_check_constraints("equipos")}
+    drop_legacy = LEGACY_TYPE_CHECK in constraints
+
+    with op.batch_alter_table("equipos", recreate="always") as batch_op:
+        if drop_legacy:
+            batch_op.drop_constraint(LEGACY_TYPE_CHECK, type_="check")
+        batch_op.alter_column("tipo_id", existing_type=sa.Integer(), nullable=False)
+        batch_op.drop_column("tipo")
+
+
+LEGACY_TYPE_CHECK = "ck_equipos_tipo"
 
 
 def downgrade() -> None:
-    tipo_enum = sa.Enum(*(slug for slug, _ in DEFAULT_TYPES), name="tipo_equipo")
-    tipo_enum.create(op.get_bind())
-
-    op.add_column(
-        "equipos",
-        sa.Column("tipo", tipo_enum, nullable=True),
-    )
-
-    bind = op.get_bind()
-    rows = bind.execute(sa.text("SELECT id, nombre FROM tipo_equipo")).fetchall()
-    mapping = {nombre.lower(): slug for slug, nombre in DEFAULT_TYPES}
-    for tipo_id, nombre in rows:
-        slug = mapping.get((nombre or "").lower(), "otro")
-        bind.execute(
-            sa.text("UPDATE equipos SET tipo = :slug WHERE tipo_id = :tipo_id"),
-            {"slug": slug, "tipo_id": tipo_id},
+    with op.batch_alter_table("equipos", recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("tipo", sa.String(length=50), nullable=True))
+        batch_op.create_check_constraint(
+            LEGACY_TYPE_CHECK,
+            f"tipo IN ({_enum_values_sql(EQUIPO_TYPE_VALUES)})",
         )
 
-    bind.execute(sa.text("UPDATE equipos SET tipo = :slug WHERE tipo IS NULL"), {"slug": "otro"})
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT e.id, COALESCE(te.slug, 'otro') AS slug "
+            "FROM equipos e LEFT JOIN tipo_equipo te ON te.id = e.tipo_id"
+        )
+    ).fetchall()
+    update_legacy = sa.text("UPDATE equipos SET tipo = :slug WHERE id = :equipo_id")
+    for equipo_id, slug in rows:
+        bind.execute(update_legacy, {"slug": slug or "otro", "equipo_id": equipo_id})
 
-    op.alter_column("equipos", "tipo", existing_type=tipo_enum, nullable=False)
+    bind.execute(sa.text("UPDATE equipos SET tipo = 'otro' WHERE tipo IS NULL"))
+
+    with op.batch_alter_table("equipos", recreate="always") as batch_op:
+        batch_op.alter_column("tipo", existing_type=sa.String(length=50), nullable=False)
+
     op.drop_constraint("fk_equipos_tipo_equipo", "equipos", type_="foreignkey")
-    op.drop_column("equipos", "tipo_id")
+
+    with op.batch_alter_table("equipos", recreate="always") as batch_op:
+        batch_op.drop_column("tipo_id")
+
     op.drop_table("tipo_equipo")
-*** End Patch

--- a/migrations/versions/bd8b7d50f9ac_add_equipo_adjuntos_and_serial_flag.py
+++ b/migrations/versions/bd8b7d50f9ac_add_equipo_adjuntos_and_serial_flag.py
@@ -43,7 +43,7 @@ def _ensure_adjuntos_table() -> None:
 
     columns = {column["name"] for column in inspector.get_columns("equipos_adjuntos")}
     if "file_size" not in columns:
-        with op.batch_alter_table("equipos_adjuntos", schema=None) as batch:
+        with op.batch_alter_table("equipos_adjuntos", schema=None, recreate="always") as batch:
             batch.add_column(sa.Column("file_size", sa.Integer(), nullable=True))
 
     indexes = {index["name"] for index in inspector.get_indexes("equipos_adjuntos")}
@@ -56,12 +56,15 @@ def _ensure_adjuntos_table() -> None:
 
 
 def upgrade():
-    op.add_column(
-        "equipos",
-        sa.Column(
-            "sin_numero_serie", sa.Boolean(), nullable=False, server_default=sa.false()
-        ),
-    )
+    with op.batch_alter_table("equipos", recreate="always") as batch:
+        batch.add_column(
+            sa.Column(
+                "sin_numero_serie",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
     _ensure_adjuntos_table()
     with op.batch_alter_table("equipos", recreate="always") as batch:
         batch.alter_column(
@@ -79,7 +82,7 @@ def downgrade():
     inspector = inspect(bind)
     columns = {column["name"] for column in inspector.get_columns("equipos_adjuntos")}
     if "file_size" in columns:
-        with op.batch_alter_table("equipos_adjuntos", schema=None) as batch:
+        with op.batch_alter_table("equipos_adjuntos", schema=None, recreate="always") as batch:
             batch.drop_column("file_size")
 
     indexes = {index["name"] for index in inspector.get_indexes("equipos_adjuntos")}

--- a/migrations/versions/c28f3d5aa8a9_initial_schema.py
+++ b/migrations/versions/c28f3d5aa8a9_initial_schema.py
@@ -1,22 +1,15 @@
-"""Initial schema.
-
-Revision ID: c28f3d5aa8a9
-Revises: 
-Create Date: 2024-01-01 00:00:00
-"""
+"""Initial schema."""
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
-
 
 revision = "c28f3d5aa8a9"
 down_revision = None
 branch_labels = None
 depends_on = None
 
-
-modulo_permiso_enum = sa.Enum(
+PERMISSION_MODULES = (
     "inventario",
     "insumos",
     "actas",
@@ -25,10 +18,9 @@ modulo_permiso_enum = sa.Enum(
     "reportes",
     "auditoria",
     "licencias",
-    name="modulo_permiso",
 )
 
-tipo_equipo_enum = sa.Enum(
+EQUIPO_TYPES = (
     "impresora",
     "router",
     "switch",
@@ -41,351 +33,392 @@ tipo_equipo_enum = sa.Enum(
     "telefono_ip",
     "ups",
     "otro",
-    name="tipo_equipo",
 )
 
-estado_equipo_enum = sa.Enum(
+EQUIPO_STATES = (
     "operativo",
     "servicio_tecnico",
     "de_baja",
     "prestado",
-    name="estado_equipo",
 )
 
-tipo_acta_enum = sa.Enum(
+ACTA_TYPES = (
     "entrega",
     "prestamo",
     "transferencia",
-    name="tipo_acta",
 )
 
-tipo_adjunto_enum = sa.Enum(
+ADJUNTO_TYPES = (
     "factura",
     "presupuesto",
     "acta",
     "planilla_patrimonial",
     "remito",
     "otro",
-    name="tipo_adjunto",
 )
 
-tipo_docscan_enum = sa.Enum(
+DOCSCAN_TYPES = (
     "nota",
     "informe",
     "contrato",
     "otro",
-    name="tipo_docscan",
 )
 
-tipo_licencia_enum = sa.Enum(
+LICENCIA_TYPES = (
     "temporal",
     "permanente",
     "especial",
-    name="tipo_licencia",
 )
 
-estado_licencia_enum = sa.Enum(
+LICENCIA_STATES = (
     "borrador",
     "pendiente",
     "aprobada",
     "rechazada",
     "cancelada",
-    name="estado_licencia",
 )
 
-tipo_movimiento_enum = sa.Enum("ingreso", "egreso", name="tipo_movimiento")
+MOVIMIENTO_TYPES = (
+    "ingreso",
+    "egreso",
+)
+
+
+def _enum_check(column: str, values: tuple[str, ...], constraint: str) -> sa.CheckConstraint:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for candidate in (value, value.upper()):
+            if candidate not in seen:
+                ordered.append(candidate)
+                seen.add(candidate)
+    options = ", ".join(f"'{value}'" for value in ordered)
+    return sa.CheckConstraint(f"{column} IN ({options})", name=constraint)
 
 
 def upgrade() -> None:
-    modulo_permiso_enum.create(op.get_bind(), checkfirst=True)
-    tipo_equipo_enum.create(op.get_bind(), checkfirst=True)
-    estado_equipo_enum.create(op.get_bind(), checkfirst=True)
-    tipo_acta_enum.create(op.get_bind(), checkfirst=True)
-    tipo_adjunto_enum.create(op.get_bind(), checkfirst=True)
-    tipo_docscan_enum.create(op.get_bind(), checkfirst=True)
-    tipo_licencia_enum.create(op.get_bind(), checkfirst=True)
-    estado_licencia_enum.create(op.get_bind(), checkfirst=True)
-    tipo_movimiento_enum.create(op.get_bind(), checkfirst=True)
-
     op.create_table(
         "hospitales",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("codigo", sa.String(length=20), nullable=True),
-        sa.Column("direccion", sa.String(length=255), nullable=True),
-        sa.Column("telefono", sa.String(length=50), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("nombre"),
-        sa.UniqueConstraint("codigo"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nombre", sa.String(length=120), nullable=False, unique=True),
+        sa.Column("codigo", sa.String(length=20), unique=True),
+        sa.Column("direccion", sa.String(length=255)),
+        sa.Column("telefono", sa.String(length=50)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
 
     op.create_table(
         "roles",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("nombre", sa.String(length=50), nullable=False),
-        sa.Column("descripcion", sa.String(length=255), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("nombre"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nombre", sa.String(length=50), nullable=False, unique=True),
+        sa.Column("descripcion", sa.String(length=255)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
 
     op.create_table(
         "servicios",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("descripcion", sa.String(length=255), nullable=True),
-        sa.Column("hospital_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="servicios_hospital_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("descripcion", sa.String(length=255)),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id"), nullable=False),
         sa.UniqueConstraint("nombre", "hospital_id", name="uq_servicio_nombre_hospital"),
     )
 
     op.create_table(
         "oficinas",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("piso", sa.String(length=20), nullable=True),
-        sa.Column("servicio_id", sa.Integer(), nullable=False),
-        sa.Column("hospital_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["servicio_id"], ["servicios.id"], name="oficinas_servicio_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="oficinas_hospital_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("piso", sa.String(length=20)),
+        sa.Column("servicio_id", sa.Integer(), sa.ForeignKey("servicios.id"), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id"), nullable=False),
         sa.UniqueConstraint("nombre", "servicio_id", name="uq_oficina_nombre_servicio"),
     )
 
     op.create_table(
         "usuarios",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("username", sa.String(length=80), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(length=80), nullable=False, unique=True),
         sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("email", sa.String(length=255), nullable=False),
-        sa.Column("telefono", sa.String(length=50), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("telefono", sa.String(length=50)),
         sa.Column("password_hash", sa.String(length=255), nullable=False),
-        sa.Column("activo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
-        sa.Column("rol_id", sa.Integer(), nullable=False),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("servicio_id", sa.Integer(), nullable=True),
-        sa.Column("oficina_id", sa.Integer(), nullable=True),
-        sa.Column("ultimo_login", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["rol_id"], ["roles.id"], name="usuarios_rol_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="usuarios_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["servicio_id"], ["servicios.id"], name="usuarios_servicio_id_fkey"),
-        sa.ForeignKeyConstraint(["oficina_id"], ["oficinas.id"], name="usuarios_oficina_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("email"),
-        sa.UniqueConstraint("username"),
+        sa.Column("activo", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("rol_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("servicio_id", sa.Integer(), sa.ForeignKey("servicios.id")),
+        sa.Column("oficina_id", sa.Integer(), sa.ForeignKey("oficinas.id")),
+        sa.Column("ultimo_login", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
 
     op.create_table(
         "permisos",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("rol_id", sa.Integer(), nullable=False),
-        sa.Column("modulo", modulo_permiso_enum, nullable=False),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("can_read", sa.Boolean(), nullable=False, server_default=sa.text("true")),
-        sa.Column("can_write", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("allow_export", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.ForeignKeyConstraint(["rol_id"], ["roles.id"], name="permisos_rol_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="permisos_hospital_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("rol_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.Column("modulo", sa.String(length=50), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("can_read", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("can_write", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("allow_export", sa.Boolean(), nullable=False, server_default=sa.false()),
+        _enum_check("modulo", PERMISSION_MODULES, "ck_permisos_modulo"),
     )
 
     op.create_table(
         "equipos",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("codigo", sa.String(length=50), nullable=True),
-        sa.Column("tipo", tipo_equipo_enum, nullable=False),
-        sa.Column("estado", estado_equipo_enum, nullable=False, server_default=sa.text("'operativo'")),
-        sa.Column("descripcion", sa.Text(), nullable=True),
-        sa.Column("marca", sa.String(length=100), nullable=True),
-        sa.Column("modelo", sa.String(length=100), nullable=True),
-        sa.Column("numero_serie", sa.String(length=120), nullable=True),
-        sa.Column("hospital_id", sa.Integer(), nullable=False),
-        sa.Column("servicio_id", sa.Integer(), nullable=True),
-        sa.Column("oficina_id", sa.Integer(), nullable=True),
-        sa.Column("responsable", sa.String(length=120), nullable=True),
-        sa.Column("fecha_compra", sa.Date(), nullable=True),
-        sa.Column("fecha_instalacion", sa.Date(), nullable=True),
-        sa.Column("garantia_hasta", sa.Date(), nullable=True),
-        sa.Column("observaciones", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="equipos_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["servicio_id"], ["servicios.id"], name="equipos_servicio_id_fkey"),
-        sa.ForeignKeyConstraint(["oficina_id"], ["oficinas.id"], name="equipos_oficina_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("codigo"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("codigo", sa.String(length=50), unique=True),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column("estado", sa.String(length=50), nullable=False, server_default=sa.text("'operativo'")),
+        sa.Column("descripcion", sa.Text()),
+        sa.Column("marca", sa.String(length=100)),
+        sa.Column("modelo", sa.String(length=100)),
+        sa.Column("numero_serie", sa.String(length=120)),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id"), nullable=False),
+        sa.Column("servicio_id", sa.Integer(), sa.ForeignKey("servicios.id")),
+        sa.Column("oficina_id", sa.Integer(), sa.ForeignKey("oficinas.id")),
+        sa.Column("responsable", sa.String(length=120)),
+        sa.Column("fecha_compra", sa.Date()),
+        sa.Column("fecha_instalacion", sa.Date()),
+        sa.Column("garantia_hasta", sa.Date()),
+        sa.Column("observaciones", sa.Text()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("estado", EQUIPO_STATES, "ck_equipos_estado"),
     )
     op.create_index("ix_equipos_numero_serie", "equipos", ["numero_serie"], unique=False)
 
     op.create_table(
         "equipos_historial",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("equipo_id", sa.Integer(), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
         sa.Column("accion", sa.String(length=120), nullable=False),
-        sa.Column("descripcion", sa.Text(), nullable=True),
-        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="equipos_historial_equipo_id_fkey"),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="equipos_historial_usuario_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("descripcion", sa.Text()),
+        sa.Column(
+            "fecha",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
 
     op.create_table(
         "insumos",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("numero_serie", sa.String(length=100), nullable=True),
-        sa.Column("descripcion", sa.Text(), nullable=True),
-        sa.Column("unidad_medida", sa.String(length=20), nullable=True),
-        sa.Column("stock", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("stock_minimo", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("costo_unitario", sa.Numeric(10, 2), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("numero_serie", sa.String(length=100)),
+        sa.Column("descripcion", sa.Text()),
+        sa.Column("unidad_medida", sa.String(length=20)),
+        sa.Column("stock", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("stock_minimo", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("costo_unitario", sa.Numeric(10, 2)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
     op.create_index("ix_insumos_numero_serie", "insumos", ["numero_serie"], unique=False)
 
     op.create_table(
         "insumo_movimientos",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("insumo_id", sa.Integer(), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=True),
-        sa.Column("equipo_id", sa.Integer(), nullable=True),
-        sa.Column("tipo", tipo_movimiento_enum, nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("insumo_id", sa.Integer(), sa.ForeignKey("insumos.id"), nullable=False),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id")),
+        sa.Column("tipo", sa.String(length=20), nullable=False),
         sa.Column("cantidad", sa.Integer(), nullable=False),
-        sa.Column("motivo", sa.String(length=255), nullable=True),
-        sa.Column("observaciones", sa.Text(), nullable=True),
-        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["insumo_id"], ["insumos.id"], name="insumo_movimientos_insumo_id_fkey"),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="insumo_movimientos_usuario_id_fkey"),
-        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="insumo_movimientos_equipo_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("motivo", sa.String(length=255)),
+        sa.Column("observaciones", sa.Text()),
+        sa.Column(
+            "fecha",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("tipo", MOVIMIENTO_TYPES, "ck_insumo_movimientos_tipo"),
     )
 
     op.create_table(
         "equipo_insumos",
-        sa.Column("equipo_id", sa.Integer(), nullable=False),
-        sa.Column("insumo_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="equipo_insumos_equipo_id_fkey"),
-        sa.ForeignKeyConstraint(["insumo_id"], ["insumos.id"], name="equipo_insumos_insumo_id_fkey"),
-        sa.PrimaryKeyConstraint("equipo_id", "insumo_id"),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), primary_key=True),
+        sa.Column("insumo_id", sa.Integer(), sa.ForeignKey("insumos.id"), primary_key=True),
     )
 
     op.create_table(
         "actas",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("numero", sa.String(length=50), nullable=True),
-        sa.Column("tipo", tipo_acta_enum, nullable=False),
-        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=True),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("servicio_id", sa.Integer(), nullable=True),
-        sa.Column("oficina_id", sa.Integer(), nullable=True),
-        sa.Column("observaciones", sa.Text(), nullable=True),
-        sa.Column("pdf_path", sa.String(length=255), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="actas_usuario_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="actas_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["servicio_id"], ["servicios.id"], name="actas_servicio_id_fkey"),
-        sa.ForeignKeyConstraint(["oficina_id"], ["oficinas.id"], name="actas_oficina_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("numero"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("numero", sa.String(length=50), unique=True),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column(
+            "fecha",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("servicio_id", sa.Integer(), sa.ForeignKey("servicios.id")),
+        sa.Column("oficina_id", sa.Integer(), sa.ForeignKey("oficinas.id")),
+        sa.Column("observaciones", sa.Text()),
+        sa.Column("pdf_path", sa.String(length=255)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("tipo", ACTA_TYPES, "ck_actas_tipo"),
     )
 
     op.create_table(
         "acta_items",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("acta_id", sa.Integer(), nullable=False),
-        sa.Column("equipo_id", sa.Integer(), nullable=True),
-        sa.Column("cantidad", sa.Integer(), nullable=False, server_default=sa.text("1")),
-        sa.Column("descripcion", sa.Text(), nullable=True),
-        sa.ForeignKeyConstraint(["acta_id"], ["actas.id"], name="acta_items_acta_id_fkey"),
-        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="acta_items_equipo_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("acta_id", sa.Integer(), sa.ForeignKey("actas.id"), nullable=False),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id")),
+        sa.Column("cantidad", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("descripcion", sa.Text()),
     )
 
     op.create_table(
         "adjuntos",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("equipo_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), nullable=False),
         sa.Column("filename", sa.String(length=255), nullable=False),
         sa.Column("path", sa.String(length=255), nullable=False),
-        sa.Column("tipo", tipo_adjunto_enum, nullable=False),
-        sa.Column("descripcion", sa.Text(), nullable=True),
-        sa.Column("uploaded_by_id", sa.Integer(), nullable=True),
-        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["equipo_id"], ["equipos.id"], name="adjuntos_equipo_id_fkey"),
-        sa.ForeignKeyConstraint(["uploaded_by_id"], ["usuarios.id"], name="adjuntos_usuario_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column("descripcion", sa.Text()),
+        sa.Column("uploaded_by_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column(
+            "uploaded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("tipo", ADJUNTO_TYPES, "ck_adjuntos_tipo"),
     )
 
     op.create_table(
         "docscan",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("titulo", sa.String(length=150), nullable=False),
-        sa.Column("tipo", tipo_docscan_enum, nullable=False),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
         sa.Column("filename", sa.String(length=255), nullable=False),
         sa.Column("path", sa.String(length=255), nullable=False),
-        sa.Column("fecha_documento", sa.Date(), nullable=True),
-        sa.Column("comentario", sa.Text(), nullable=True),
-        sa.Column("usuario_id", sa.Integer(), nullable=True),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("servicio_id", sa.Integer(), nullable=True),
-        sa.Column("oficina_id", sa.Integer(), nullable=True),
-        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="docscan_usuario_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="docscan_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["servicio_id"], ["servicios.id"], name="docscan_servicio_id_fkey"),
-        sa.ForeignKeyConstraint(["oficina_id"], ["oficinas.id"], name="docscan_oficina_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("fecha_documento", sa.Date()),
+        sa.Column("comentario", sa.Text()),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("servicio_id", sa.Integer(), sa.ForeignKey("servicios.id")),
+        sa.Column("oficina_id", sa.Integer(), sa.ForeignKey("oficinas.id")),
+        sa.Column(
+            "uploaded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("tipo", DOCSCAN_TYPES, "ck_docscan_tipo"),
     )
 
     op.create_table(
         "licencias",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=False),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("tipo", tipo_licencia_enum, nullable=False),
-        sa.Column("estado", estado_licencia_enum, nullable=False, server_default=sa.text("'borrador'")),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id"), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column("estado", sa.String(length=50), nullable=False, server_default=sa.text("'borrador'")),
         sa.Column("fecha_inicio", sa.Date(), nullable=False),
         sa.Column("fecha_fin", sa.Date(), nullable=False),
         sa.Column("motivo", sa.Text(), nullable=False),
-        sa.Column("comentario", sa.Text(), nullable=True),
-        sa.Column("requires_replacement", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("reemplazo_id", sa.Integer(), nullable=True),
-        sa.Column("aprobado_por_id", sa.Integer(), nullable=True),
-        sa.Column("aprobado_en", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="licencias_usuario_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="licencias_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["reemplazo_id"], ["usuarios.id"], name="licencias_reemplazo_id_fkey"),
-        sa.ForeignKeyConstraint(["aprobado_por_id"], ["usuarios.id"], name="licencias_aprobado_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("comentario", sa.Text()),
+        sa.Column("requires_replacement", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("reemplazo_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("aprobado_por_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("aprobado_en", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
+        _enum_check("tipo", LICENCIA_TYPES, "ck_licencias_tipo"),
+        _enum_check("estado", LICENCIA_STATES, "ck_licencias_estado"),
     )
     op.create_index("ix_licencias_estado_tipo", "licencias", ["estado", "tipo"], unique=False)
     op.create_index("ix_licencias_usuario_id", "licencias", ["usuario_id"], unique=False)
 
     op.create_table(
         "auditoria",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
         sa.Column("accion", sa.String(length=150), nullable=False),
-        sa.Column("modulo", sa.String(length=50), nullable=True),
-        sa.Column("tabla", sa.String(length=100), nullable=True),
-        sa.Column("registro_id", sa.Integer(), nullable=True),
-        sa.Column("ip_address", sa.String(length=45), nullable=True),
-        sa.Column("datos", sa.Text(), nullable=True),
-        sa.Column("fecha", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="auditoria_usuario_id_fkey"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("modulo", sa.String(length=50)),
+        sa.Column("tabla", sa.String(length=100)),
+        sa.Column("registro_id", sa.Integer()),
+        sa.Column("ip_address", sa.String(length=45)),
+        sa.Column("datos", sa.Text()),
+        sa.Column(
+            "fecha",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        ),
     )
 
 
@@ -411,13 +444,3 @@ def downgrade() -> None:
     op.drop_table("servicios")
     op.drop_table("roles")
     op.drop_table("hospitales")
-
-    tipo_movimiento_enum.drop(op.get_bind(), checkfirst=True)
-    estado_licencia_enum.drop(op.get_bind(), checkfirst=True)
-    tipo_licencia_enum.drop(op.get_bind(), checkfirst=True)
-    tipo_docscan_enum.drop(op.get_bind(), checkfirst=True)
-    tipo_adjunto_enum.drop(op.get_bind(), checkfirst=True)
-    tipo_acta_enum.drop(op.get_bind(), checkfirst=True)
-    estado_equipo_enum.drop(op.get_bind(), checkfirst=True)
-    tipo_equipo_enum.drop(op.get_bind(), checkfirst=True)
-    modulo_permiso_enum.drop(op.get_bind(), checkfirst=True)

--- a/migrations/versions/d2f6f3b4a1c9_restructure_licencias_table.py
+++ b/migrations/versions/d2f6f3b4a1c9_restructure_licencias_table.py
@@ -5,76 +5,63 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
 
-# revision identifiers, used by Alembic.
 revision = "d2f6f3b4a1c9"
 down_revision = "c6be45c2d4ab"
 branch_labels = None
 depends_on = None
 
-old_tipo_enum = sa.Enum(
-    "temporal",
-    "permanente",
-    "especial",
-    name="tipo_licencia",
-)
+OLD_TIPO_VALUES = ("temporal", "permanente", "especial")
+OLD_ESTADO_VALUES = ("borrador", "pendiente", "aprobada", "rechazada", "cancelada")
+NEW_TIPO_VALUES = ("vacaciones", "enfermedad", "estudio", "otro")
+NEW_ESTADO_VALUES = ("solicitada", "aprobada", "rechazada", "cancelada")
 
-old_estado_enum = sa.Enum(
-    "borrador",
-    "pendiente",
-    "aprobada",
-    "rechazada",
-    "cancelada",
-    name="estado_licencia",
-)
 
-new_tipo_enum = sa.Enum(
-    "vacaciones",
-    "enfermedad",
-    "estudio",
-    "otro",
-    name="tipo_licencia",
-)
+def _enum_values_sql(values: tuple[str, ...]) -> str:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for candidate in (value, value.upper()):
+            if candidate not in seen:
+                ordered.append(candidate)
+                seen.add(candidate)
+    return ", ".join(f"'{value}'" for value in ordered)
 
-new_estado_enum = sa.Enum(
-    "solicitada",
-    "aprobada",
-    "rechazada",
-    "cancelada",
-    name="estado_licencia",
-)
+
+def _enum_check(column: str, values: tuple[str, ...], name: str) -> sa.CheckConstraint:
+    return sa.CheckConstraint(f"{column} IN ({_enum_values_sql(values)})", name=name)
+
+
+def _drop_licencias_if_exists(inspector: inspect.Inspector) -> None:
+    if "licencias" not in inspector.get_table_names():
+        return
+    indexes = {index["name"] for index in inspector.get_indexes("licencias")}
+    if "ix_licencias_fecha_inicio_fecha_fin" in indexes:
+        op.drop_index("ix_licencias_fecha_inicio_fecha_fin", table_name="licencias")
+    if "ix_licencias_estado" in indexes:
+        op.drop_index("ix_licencias_estado", table_name="licencias")
+    if "ix_licencias_user_id" in indexes:
+        op.drop_index("ix_licencias_user_id", table_name="licencias")
+    op.drop_table("licencias")
 
 
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
-    tables = inspector.get_table_names()
 
-    if "licencias" in tables:
-        op.drop_table("licencias")
-
-    old_estado_enum.drop(bind, checkfirst=True)
-    old_tipo_enum.drop(bind, checkfirst=True)
-
-    new_tipo_enum.create(bind, checkfirst=True)
-    new_estado_enum.create(bind, checkfirst=True)
+    _drop_licencias_if_exists(inspector)
 
     op.create_table(
         "licencias",
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("user_id", sa.Integer(), sa.ForeignKey("usuarios.id"), nullable=False),
-        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id"), nullable=True),
-        sa.Column("tipo", new_tipo_enum, nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
         sa.Column("fecha_inicio", sa.Date(), nullable=False),
         sa.Column("fecha_fin", sa.Date(), nullable=False),
         sa.Column("motivo", sa.Text(), nullable=False),
-        sa.Column(
-            "estado",
-            new_estado_enum,
-            nullable=False,
-            server_default=sa.text("'solicitada'"),
-        ),
-        sa.Column("decidido_por", sa.Integer(), sa.ForeignKey("usuarios.id"), nullable=True),
-        sa.Column("decidido_en", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("estado", sa.String(length=50), nullable=False, server_default=sa.text("'solicitada'")),
+        sa.Column("decidido_por", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("decidido_en", sa.DateTime(timezone=True)),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -87,6 +74,8 @@ def upgrade() -> None:
             server_default=sa.func.current_timestamp(),
             nullable=False,
         ),
+        _enum_check("tipo", NEW_TIPO_VALUES, "ck_licencias_tipo"),
+        _enum_check("estado", NEW_ESTADO_VALUES, "ck_licencias_estado"),
     )
 
     op.create_index("ix_licencias_user_id", "licencias", ["user_id"], unique=False)
@@ -102,50 +91,24 @@ def upgrade() -> None:
 def downgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
-    tables = inspector.get_table_names()
 
-    if "licencias" in tables:
-        indexes = {index["name"] for index in inspector.get_indexes("licencias")}
-        if "ix_licencias_fecha_inicio_fecha_fin" in indexes:
-            op.drop_index("ix_licencias_fecha_inicio_fecha_fin", table_name="licencias")
-        if "ix_licencias_estado" in indexes:
-            op.drop_index("ix_licencias_estado", table_name="licencias")
-        if "ix_licencias_user_id" in indexes:
-            op.drop_index("ix_licencias_user_id", table_name="licencias")
-
-        op.drop_table("licencias")
-
-    new_estado_enum.drop(bind, checkfirst=True)
-    new_tipo_enum.drop(bind, checkfirst=True)
-
-    old_tipo_enum.create(bind, checkfirst=True)
-    old_estado_enum.create(bind, checkfirst=True)
+    _drop_licencias_if_exists(inspector)
 
     op.create_table(
         "licencias",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("usuario_id", sa.Integer(), nullable=False),
-        sa.Column("hospital_id", sa.Integer(), nullable=True),
-        sa.Column("tipo", old_tipo_enum, nullable=False),
-        sa.Column(
-            "estado",
-            old_estado_enum,
-            nullable=False,
-            server_default=sa.text("'borrador'"),
-        ),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id"), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column("estado", sa.String(length=50), nullable=False, server_default=sa.text("'borrador'")),
         sa.Column("fecha_inicio", sa.Date(), nullable=False),
         sa.Column("fecha_fin", sa.Date(), nullable=False),
         sa.Column("motivo", sa.Text(), nullable=False),
-        sa.Column("comentario", sa.Text(), nullable=True),
-        sa.Column(
-            "requires_replacement",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("false"),
-        ),
-        sa.Column("reemplazo_id", sa.Integer(), nullable=True),
-        sa.Column("aprobado_por_id", sa.Integer(), nullable=True),
-        sa.Column("aprobado_en", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("comentario", sa.Text()),
+        sa.Column("requires_replacement", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("reemplazo_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("aprobado_por_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column("aprobado_en", sa.DateTime(timezone=True)),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -158,11 +121,8 @@ def downgrade() -> None:
             server_default=sa.func.current_timestamp(),
             nullable=False,
         ),
-        sa.PrimaryKeyConstraint("id"),
-        sa.ForeignKeyConstraint(["usuario_id"], ["usuarios.id"], name="licencias_usuario_id_fkey"),
-        sa.ForeignKeyConstraint(["hospital_id"], ["hospitales.id"], name="licencias_hospital_id_fkey"),
-        sa.ForeignKeyConstraint(["reemplazo_id"], ["usuarios.id"], name="licencias_reemplazo_id_fkey"),
-        sa.ForeignKeyConstraint(["aprobado_por_id"], ["usuarios.id"], name="licencias_aprobado_id_fkey"),
+        _enum_check("tipo", OLD_TIPO_VALUES, "ck_licencias_tipo"),
+        _enum_check("estado", OLD_ESTADO_VALUES, "ck_licencias_estado"),
     )
 
     op.create_index("ix_licencias_estado_tipo", "licencias", ["estado", "tipo"], unique=False)

--- a/migrations/versions/e1d3f9c5c1d5_add_theme_pref_and_rejection_reason.py
+++ b/migrations/versions/e1d3f9c5c1d5_add_theme_pref_and_rejection_reason.py
@@ -4,37 +4,48 @@ from __future__ import annotations
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
 revision = "e1d3f9c5c1d5"
 down_revision = "d2f6f3b4a1c9"
 branch_labels = None
 depends_on = None
 
+THEME_VALUES = ("light", "dark", "system", "LIGHT", "DARK", "SYSTEM")
 
-theme_enum = sa.Enum("light", "dark", "system", name="theme_preference")
+
+def _enum_values_sql(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    theme_enum.create(bind, checkfirst=True)
+    with op.batch_alter_table("usuarios", recreate="always") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "theme_pref",
+                sa.String(length=20),
+                nullable=False,
+                server_default=sa.text("'system'"),
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_usuarios_theme_pref",
+            f"theme_pref IN ({_enum_values_sql(THEME_VALUES)})",
+        )
 
-    op.add_column(
-        "usuarios",
-        sa.Column(
+    with op.batch_alter_table("usuarios", recreate="always") as batch_op:
+        batch_op.alter_column(
             "theme_pref",
-            theme_enum,
-            nullable=False,
-            server_default="system",
-        ),
-    )
+            existing_type=sa.String(length=20),
+            server_default=None,
+        )
 
-    op.add_column("licencias", sa.Column("motivo_rechazo", sa.Text(), nullable=True))
+    with op.batch_alter_table("licencias", recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("motivo_rechazo", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("licencias", "motivo_rechazo")
+    with op.batch_alter_table("licencias", recreate="always") as batch_op:
+        batch_op.drop_column("motivo_rechazo")
 
-    op.drop_column("usuarios", "theme_pref")
-
-    bind = op.get_bind()
-    theme_enum.drop(bind, checkfirst=True)
+    with op.batch_alter_table("usuarios", recreate="always") as batch_op:
+        batch_op.drop_constraint("ck_usuarios_theme_pref", type_="check")
+        batch_op.drop_column("theme_pref")

--- a/migrations/versions/f3c92c1f2f6d_add_dni_unique_to_usuarios.py
+++ b/migrations/versions/f3c92c1f2f6d_add_dni_unique_to_usuarios.py
@@ -18,7 +18,7 @@ usuarios_table = sa.table(
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("usuarios", schema=None) as batch_op:
+    with op.batch_alter_table("usuarios", schema=None, recreate="always") as batch_op:
         batch_op.add_column(sa.Column("dni", sa.String(length=20), nullable=True))
 
     bind = op.get_bind()
@@ -31,14 +31,14 @@ def upgrade() -> None:
             .values(dni=generated_dni)
         )
 
-    with op.batch_alter_table("usuarios", schema=None) as batch_op:
+    with op.batch_alter_table("usuarios", schema=None, recreate="always") as batch_op:
         batch_op.alter_column("dni", existing_type=sa.String(length=20), nullable=False)
         batch_op.create_unique_constraint("uq_usuario_dni", ["dni"])
         batch_op.create_unique_constraint("uq_usuario_username", ["username"])
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("usuarios", schema=None) as batch_op:
+    with op.batch_alter_table("usuarios", schema=None, recreate="always") as batch_op:
         batch_op.drop_constraint("uq_usuario_username", type_="unique")
         batch_op.drop_constraint("uq_usuario_dni", type_="unique")
         batch_op.drop_column("dni")

--- a/seeds/seed.py
+++ b/seeds/seed.py
@@ -140,7 +140,9 @@ def create_equipment_types(session: Session) -> dict[str, TipoEquipo]:
         ("ups", "UPS"),
         ("otro", "Otro"),
     ]
-    registros = [TipoEquipo(nombre=nombre, activo=True) for _, nombre in defaults]
+    registros = [
+        TipoEquipo(slug=slug, nombre=nombre, activo=True) for slug, nombre in defaults
+    ]
     session.add_all(registros)
     session.flush()
     return {slug: registro for (slug, _), registro in zip(defaults, registros)}


### PR DESCRIPTION
## Summary
- Restore the Alembic environment so migrations auto-discover models, reuse the configured database URL and enable SQLite batch mode.
- Rewrite the initial schema and equipment type catalogue migrations to rely on string columns with check constraints, add the new `tipo_equipo` catalogue, and backfill existing equipment while the ORM/seed data manage slugs automatically.
- Guard the license check before request until the core tables exist and document the SQLite-first boot flow.

## Testing
- flask db upgrade
- python seeds/seed.py
- curl -I http://127.0.0.1:5000/
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5c0da93548324812d64757156bd99