### PR TITLE
feat: registrar alta diferenciada para equipos nuevos

### DIFF
--- a/app/models/equipo.py
+++ b/app/models/equipo.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     DateTime,
     Enum as SAEnum,
     ForeignKey,
+    Integer,
     String,
     Text,
     event,
@@ -105,10 +106,15 @@ class Equipo(Base):
     servicio_id: Mapped[int | None] = mapped_column(ForeignKey("servicios.id"))
     oficina_id: Mapped[int | None] = mapped_column(ForeignKey("oficinas.id"))
     responsable: Mapped[str | None] = mapped_column(String(120))
-    fecha_compra: Mapped[date | None] = mapped_column(Date())
+    fecha_ingreso: Mapped[date | None] = mapped_column("fecha_compra", Date())
     fecha_instalacion: Mapped[date | None] = mapped_column(Date())
     garantia_hasta: Mapped[date | None] = mapped_column(Date())
     observaciones: Mapped[str | None] = mapped_column(Text())
+    es_nuevo: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    expediente: Mapped[str | None] = mapped_column(String(120))
+    anio_expediente: Mapped[int | None] = mapped_column(Integer())
+    orden_compra: Mapped[str | None] = mapped_column(String(120))
+    tipo_adquisicion: Mapped[str | None] = mapped_column(String(50))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
     )

--- a/app/routes/equipos/routes.py
+++ b/app/routes/equipos/routes.py
@@ -251,12 +251,18 @@ def crear():
             servicio_id=servicio.id if servicio else None,
             oficina_id=oficina.id if oficina else None,
             responsable=form.responsable.data or None,
-            fecha_compra=form.fecha_compra.data,
+            fecha_ingreso=form.fecha_ingreso.data,
             fecha_instalacion=form.fecha_instalacion.data,
             garantia_hasta=form.garantia_hasta.data,
             observaciones=form.observaciones.data or None,
+            es_nuevo=bool(form.es_nuevo.data),
+            expediente=form.expediente.data or None,
+            anio_expediente=form.anio_expediente.data or None,
+            orden_compra=form.orden_compra.data or None,
+            tipo_adquisicion=form.tipo_adquisicion.data or None,
         )
-        equipo.registrar_evento(current_user, "Alta", "Creación de equipo")
+        detalle_alta = "Alta de equipo nuevo" if form.es_nuevo.data else "Alta de equipo usado"
+        equipo.registrar_evento(current_user, "Alta", detalle_alta)
         db.session.add(equipo)
         db.session.commit()
         log_action(
@@ -395,10 +401,15 @@ def editar(equipo_id: int):
         equipo.servicio_id = servicio.id if servicio else None
         equipo.oficina_id = oficina.id if oficina else None
         equipo.responsable = form.responsable.data or None
-        equipo.fecha_compra = form.fecha_compra.data
+        equipo.fecha_ingreso = form.fecha_ingreso.data
         equipo.fecha_instalacion = form.fecha_instalacion.data
         equipo.garantia_hasta = form.garantia_hasta.data
         equipo.observaciones = form.observaciones.data or None
+        equipo.es_nuevo = bool(form.es_nuevo.data)
+        equipo.expediente = form.expediente.data or None
+        equipo.anio_expediente = form.anio_expediente.data or None
+        equipo.orden_compra = form.orden_compra.data or None
+        equipo.tipo_adquisicion = form.tipo_adquisicion.data or None
         equipo.registrar_evento(current_user, "Actualización", "Edición de equipo")
         db.session.commit()
         log_action(usuario_id=current_user.id, accion="editar", modulo="inventario", tabla="equipos", registro_id=equipo.id)

--- a/app/static/js/equipos_form.js
+++ b/app/static/js/equipos_form.js
@@ -243,8 +243,36 @@
     });
   }
 
+  function handleNuevoEquipoToggle() {
+    const nuevoSwitch = document.getElementById('esNuevoSwitch');
+    if (!nuevoSwitch) {
+      return;
+    }
+    const container = document.querySelector('[data-nuevo-fields]');
+    if (!container) {
+      return;
+    }
+    const toggleFields = () => {
+      if (nuevoSwitch.checked) {
+        container.removeAttribute('hidden');
+      } else {
+        container.setAttribute('hidden', '');
+        container.querySelectorAll('input, select').forEach((input) => {
+          if (input.type === 'checkbox' || input.type === 'radio') {
+            input.checked = false;
+          } else {
+            input.value = '';
+          }
+        });
+      }
+    };
+    nuevoSwitch.addEventListener('change', toggleFields);
+    toggleFields();
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     handleUbicacionSelects();
     handleSerialToggle();
+    handleNuevoEquipoToggle();
   });
 })();

--- a/app/templates/equipos/_form.html
+++ b/app/templates/equipos/_form.html
@@ -120,10 +120,25 @@
       {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3, placeholder='Descripción breve del equipo') }}
       {{ render_field(form.marca, form_group_class='col-12 col-md-4', placeholder='Marca') }}
       {{ render_field(form.modelo, form_group_class='col-12 col-md-4', placeholder='Modelo') }}
-      {{ render_field(form.fecha_compra, form_group_class='col-12 col-md-4', input_type='date') }}
+      {{ render_field(form.fecha_ingreso, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='date') }}
       {{ render_textarea(form.observaciones, form_group_class='col-12', rows=3, placeholder='Observaciones relevantes') }}
+    </div>
+  </div>
+  <div class="form-section">
+    <div class="section-header d-flex align-items-center justify-content-between">
+      <span>Alta del equipo</span>
+      <div class="form-check form-switch mb-0">
+        {{ form.es_nuevo(class='form-check-input', id='esNuevoSwitch') }}
+        <label class="form-check-label" for="esNuevoSwitch">Equipo nuevo</label>
+      </div>
+    </div>
+    <div class="section-body row g-3" data-nuevo-fields hidden>
+      {{ render_field(form.expediente, form_group_class='col-12 col-md-6', placeholder='Número de expediente') }}
+      {{ render_field(form.anio_expediente, form_group_class='col-12 col-md-3', input_type='number') }}
+      {{ render_field(form.orden_compra, form_group_class='col-12 col-md-6', placeholder='Orden de compra') }}
+      {{ render_select(form.tipo_adquisicion, form_group_class='col-12 col-md-3', label_class='form-label') }}
     </div>
   </div>
   <div class="d-flex flex-column flex-md-row gap-2 justify-content-end">

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -76,7 +76,27 @@
     <div class="card h-100">
       <div class="card-body">
         <h6 class="text-muted">Fechas</h6>
-        <p class="mb-0">Compra: {{ equipo.fecha_compra or '—' }}<br>Instalación: {{ equipo.fecha_instalacion or '—' }}<br>Garantía: {{ equipo.garantia_hasta or '—' }}</p>
+        <p class="mb-0">Ingreso: {{ equipo.fecha_ingreso or '—' }}<br>Instalación: {{ equipo.fecha_instalacion or '—' }}<br>Garantía: {{ equipo.garantia_hasta or '—' }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <h6 class="text-muted">Alta</h6>
+        <p class="mb-2">
+          <span class="badge rounded-pill {% if equipo.es_nuevo %}bg-success-subtle text-success-emphasis{% else %}bg-secondary-subtle text-secondary-emphasis{% endif %}">{{ 'Nuevo' if equipo.es_nuevo else 'Usado' }}</span>
+        </p>
+        <dl class="row mb-0 small">
+          <dt class="col-6">Expediente</dt>
+          <dd class="col-6 text-truncate">{{ equipo.expediente or '—' }}</dd>
+          <dt class="col-6">Año</dt>
+          <dd class="col-6">{{ equipo.anio_expediente or '—' }}</dd>
+          <dt class="col-6">Orden de compra</dt>
+          <dd class="col-6 text-truncate">{{ equipo.orden_compra or '—' }}</dd>
+          <dt class="col-6">Tipo adquisición</dt>
+          <dd class="col-6">{{ equipo.tipo_adquisicion|replace('_', ' ')|title if equipo.tipo_adquisicion else '—' }}</dd>
+        </dl>
       </div>
     </div>
   </div>

--- a/app/templates/equipos/listar.html
+++ b/app/templates/equipos/listar.html
@@ -47,7 +47,12 @@
         } %}
         {% set estado_class = estado_clases.get((equipo.estado.name if equipo.estado is not none else '') , 'status-badge--muted') %}
         <td>
-          <div class="fw-semibold">{{ equipo_titulo }}</div>
+          <div class="d-flex align-items-center gap-2">
+            <div class="fw-semibold mb-0">{{ equipo_titulo }}</div>
+            <span class="badge rounded-pill {% if equipo.es_nuevo %}bg-success-subtle text-success-emphasis{% else %}bg-secondary-subtle text-secondary-emphasis{% endif %}">
+              {{ 'Nuevo' if equipo.es_nuevo else 'Usado' }}
+            </span>
+          </div>
           <div class="text-muted small">{{ equipo.descripcion or 'Sin descripción registrada' }}</div>
         </td>
         <td>{{ equipo.codigo or '—' }}</td>

--- a/migrations/versions/2f1a4b2b1234_equipo_nuevo_fields.py
+++ b/migrations/versions/2f1a4b2b1234_equipo_nuevo_fields.py
@@ -1,0 +1,42 @@
+"""Add fields for new equipment intake details."""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "2f1a4b2b1234"
+down_revision = "c6be45c2d4ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "equipos",
+        sa.Column("es_nuevo", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "equipos",
+        sa.Column("expediente", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "equipos",
+        sa.Column("anio_expediente", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "equipos",
+        sa.Column("orden_compra", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "equipos",
+        sa.Column("tipo_adquisicion", sa.String(length=50), nullable=True),
+    )
+    op.execute("UPDATE equipos SET es_nuevo = FALSE WHERE es_nuevo IS NULL")
+    op.alter_column("equipos", "es_nuevo", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("equipos", "tipo_adquisicion")
+    op.drop_column("equipos", "orden_compra")
+    op.drop_column("equipos", "anio_expediente")
+    op.drop_column("equipos", "expediente")
+    op.drop_column("equipos", "es_nuevo")


### PR DESCRIPTION
## Summary
- rename the equipment intake date field and track additional acquisition metadata for new assets
- refresh create/edit equipment forms with a toggle for equipment nuevo, dynamic sections, and updated listings/detail badges
- ensure tipo de equipo validation errors are deduplicated and add the corresponding migration for the new columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0026e1908324a2b160eac4b0c41a