### PR TITLE
Add live search API, hospital assignments, and audit filters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,6 +94,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     from app.routes.adjuntos import adjuntos_bp
     from app.routes.api import api_bp
     from app.routes.auth import auth_bp
+    from app.routes.auditoria import auditoria_bp
     from app.routes.docscan import docscan_bp
     from app.routes.equipos import equipos_bp
     from app.routes.insumos import insumos_bp
@@ -101,6 +102,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     from app.routes.main import main_bp
     from app.routes.permisos import permisos_bp
     from app.routes.search import search_bp
+    from app.routes.search_api import search_api_bp
     from app.routes.usuarios import usuarios_bp
     from app.routes.ubicaciones import ubicaciones_bp
     from app.routes.ubicaciones_api import ubicaciones_api_bp
@@ -114,10 +116,12 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         adjuntos_bp,
         docscan_bp,
         permisos_bp,
+        auditoria_bp,
         actas_bp,
         search_bp,
         licencias_bp,
         api_bp,
+        search_api_bp,
         ubicaciones_api_bp,
         usuarios_bp,
     ):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ from .docscan import Docscan, TipoDocscan
 from .equipo import Equipo, EquipoHistorial, EstadoEquipo, TipoEquipo
 from .equipo_adjunto import EquipoAdjunto
 from .hospital import Hospital, Oficina, Servicio
+from .hospital_usuario_rol import HospitalUsuarioRol
 from .insumo import Insumo, InsumoMovimiento, MovimientoTipo, equipo_insumos
 from .licencia import Licencia, TipoLicencia, EstadoLicencia
 from .permisos import Modulo, Permiso
@@ -33,6 +34,7 @@ __all__ = [
     "Hospital",
     "Servicio",
     "Oficina",
+    "HospitalUsuarioRol",
     "Insumo",
     "InsumoMovimiento",
     "MovimientoTipo",

--- a/app/models/auditoria.py
+++ b/app/models/auditoria.py
@@ -4,33 +4,37 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
 
 if TYPE_CHECKING:  # pragma: no cover
+    from .hospital import Hospital
     from .usuario import Usuario
 
 
 class Auditoria(Base):
     """Audit entry storing who, what and when."""
 
-    __tablename__ = "auditoria"
+    __tablename__ = "auditorias"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     usuario_id: Mapped[int | None] = mapped_column(ForeignKey("usuarios.id"))
-    accion: Mapped[str] = mapped_column(String(150), nullable=False)
+    hospital_id: Mapped[int | None] = mapped_column(ForeignKey("hospitales.id"))
     modulo: Mapped[str | None] = mapped_column(String(50))
-    tabla: Mapped[str | None] = mapped_column(String(100))
-    registro_id: Mapped[int | None] = mapped_column(Integer)
+    accion: Mapped[str] = mapped_column(String(50), nullable=False)
+    entidad: Mapped[str | None] = mapped_column(String(50))
+    entidad_id: Mapped[int | None] = mapped_column(Integer)
+    descripcion: Mapped[str | None] = mapped_column(Text())
+    cambios: Mapped[dict | None] = mapped_column(JSON)
     ip_address: Mapped[str | None] = mapped_column(String(45))
-    datos: Mapped[str | None] = mapped_column(Text())
-    fecha: Mapped[datetime] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.current_timestamp(), nullable=False
     )
 
     usuario: Mapped["Usuario | None"] = relationship("Usuario")
+    hospital: Mapped["Hospital | None"] = relationship("Hospital")
 
 
 __all__ = ["Auditoria"]

--- a/app/models/hospital_usuario_rol.py
+++ b/app/models/hospital_usuario_rol.py
@@ -1,0 +1,32 @@
+"""Association table linking usuarios, hospitales and roles."""
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class HospitalUsuarioRol(Base):
+    """Assignment of a ``Usuario`` to a ``Hospital`` with a specific ``Rol``."""
+
+    __tablename__ = "hospital_usuario_rol"
+    __table_args__ = (
+        UniqueConstraint(
+            "usuario_id",
+            "hospital_id",
+            name="uq_usuario_hospital_asignacion",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    usuario_id: Mapped[int] = mapped_column(ForeignKey("usuarios.id"), nullable=False)
+    hospital_id: Mapped[int] = mapped_column(ForeignKey("hospitales.id"), nullable=False)
+    rol_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), nullable=False)
+
+    usuario = relationship("Usuario", back_populates="hospitales_roles")
+    hospital = relationship("Hospital", back_populates="usuarios_roles")
+    rol = relationship("Rol", back_populates="usuarios_hospitales")
+
+
+__all__ = ["HospitalUsuarioRol"]

--- a/app/models/rol.py
+++ b/app/models/rol.py
@@ -23,6 +23,9 @@ class Rol(Base):
 
     usuarios = relationship("Usuario", back_populates="rol")
     permisos = relationship("Permiso", back_populates="rol", cascade="all, delete-orphan")
+    usuarios_hospitales = relationship(
+        "HospitalUsuarioRol", back_populates="rol", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"Rol(id={self.id!r}, nombre={self.nombre!r})"

--- a/app/models/ubicacion.py
+++ b/app/models/ubicacion.py
@@ -11,6 +11,7 @@ from .base import Base
 
 if TYPE_CHECKING:  # pragma: no cover
     from .equipo import Equipo
+    from .hospital_usuario_rol import HospitalUsuarioRol
     from .licencia import Licencia
     from .permisos import Permiso
     from .usuario import Usuario
@@ -43,6 +44,9 @@ class Hospital(Base):
         "Oficina", back_populates="hospital", cascade="all, delete-orphan"
     )
     usuarios: Mapped[list["Usuario"]] = relationship("Usuario", back_populates="hospital")
+    usuarios_roles: Mapped[list["HospitalUsuarioRol"]] = relationship(
+        "HospitalUsuarioRol", back_populates="hospital", cascade="all, delete-orphan"
+    )
     licencias: Mapped[list["Licencia"]] = relationship("Licencia", back_populates="hospital")
     equipos: Mapped[list["Equipo"]] = relationship("Equipo", back_populates="hospital")
     permisos: Mapped[list["Permiso"]] = relationship("Permiso", back_populates="hospital")

--- a/app/routes/auditoria.py
+++ b/app/routes/auditoria.py
@@ -1,0 +1,94 @@
+"""Blueprint exposing audit trail with advanced filters."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from flask import Blueprint, render_template, request
+from flask_login import current_user, login_required
+
+from app.models import Auditoria, Hospital, Usuario
+from app.security import require_roles
+from app.utils.search import apply_text_search, paginate_query
+
+
+auditoria_bp = Blueprint("auditoria", __name__, url_prefix="/auditorias")
+
+
+@auditoria_bp.route("/")
+@login_required
+@require_roles("admin", "superadmin")
+def index():
+    q = (request.args.get("q", "") or "").strip()
+    usuario_id = request.args.get("usuario_id", type=int)
+    hospital_id = request.args.get("hospital_id", type=int)
+    modulo = (request.args.get("modulo") or "").strip() or None
+    accion = (request.args.get("accion") or "").strip() or None
+    fecha_desde = request.args.get("desde")
+    fecha_hasta = request.args.get("hasta")
+
+    def parse_date(value: str | None):
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+    desde_dt = parse_date(fecha_desde)
+    hasta_dt = parse_date(fecha_hasta)
+
+    query = Auditoria.query.outerjoin(Auditoria.usuario).outerjoin(Auditoria.hospital)
+    allowed_hospitals = current_user.allowed_hospital_ids()
+    if allowed_hospitals:
+        query = query.filter(
+            Auditoria.hospital_id.is_(None) | Auditoria.hospital_id.in_(allowed_hospitals)
+        )
+
+    if usuario_id:
+        query = query.filter(Auditoria.usuario_id == usuario_id)
+    if hospital_id:
+        query = query.filter(Auditoria.hospital_id == hospital_id)
+    if modulo:
+        query = query.filter(Auditoria.modulo == modulo)
+    if accion:
+        query = query.filter(Auditoria.accion == accion)
+
+    if desde_dt:
+        query = query.filter(Auditoria.created_at >= desde_dt)
+    if hasta_dt:
+        query = query.filter(Auditoria.created_at <= hasta_dt)
+
+    if q:
+        query = apply_text_search(
+            query,
+            (Auditoria.descripcion, Auditoria.modulo, Auditoria.accion, Auditoria.entidad),
+            q,
+        )
+
+    page = request.args.get("page", type=int, default=1)
+    per_page = request.args.get("per_page", type=int, default=20)
+    pagination = paginate_query(
+        query.order_by(Auditoria.created_at.desc()), page=page, per_page=per_page
+    )
+
+    usuarios = Usuario.query.order_by(Usuario.nombre).all()
+    hospitales = Hospital.query.order_by(Hospital.nombre).all()
+
+    return render_template(
+        "auditoria/index.html",
+        pagination=pagination,
+        filtros={
+            "q": q,
+            "usuario_id": usuario_id,
+            "hospital_id": hospital_id,
+            "modulo": modulo,
+            "accion": accion,
+            "desde": fecha_desde,
+            "hasta": fecha_hasta,
+        },
+        usuarios=usuarios,
+        hospitales=hospitales,
+    )
+
+
+__all__ = ["auditoria_bp"]

--- a/app/routes/licencias/routes.py
+++ b/app/routes/licencias/routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask import Blueprint, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 
@@ -250,8 +250,10 @@ def aprobar(licencia_id: int):
     try:
         aprobar_licencia(licencia, current_user)
         flash("Licencia aprobada", "success")
+        response = {"ok": True, "estado": licencia.estado.value}
     except ValueError as exc:  # pragma: no cover - defensive
         flash(str(exc), "warning")
+        response = {"ok": False, "error": str(exc)}
     else:
         log_action(
             usuario_id=current_user.id,
@@ -260,6 +262,10 @@ def aprobar(licencia_id: int):
             tabla="licencias",
             registro_id=licencia.id,
         )
+    if request.accept_mimetypes.accept_json:
+        status = 200 if response.get("ok") else 400
+        response.update({"licencia_id": licencia.id})
+        return jsonify(response), status
     return redirect(request.referrer or url_for("licencias.gestion"))
 
 
@@ -275,8 +281,10 @@ def rechazar(licencia_id: int):
     try:
         rechazar_licencia(licencia, current_user, form.motivo_rechazo.data)
         flash("Licencia rechazada", "info")
+        response = {"ok": True, "estado": licencia.estado.value}
     except ValueError as exc:  # pragma: no cover - defensive
         flash(str(exc), "warning")
+        response = {"ok": False, "error": str(exc)}
     else:
         log_action(
             usuario_id=current_user.id,
@@ -285,6 +293,10 @@ def rechazar(licencia_id: int):
             tabla="licencias",
             registro_id=licencia.id,
         )
+    if request.accept_mimetypes.accept_json:
+        status = 200 if response.get("ok") else 400
+        response.update({"licencia_id": licencia.id})
+        return jsonify(response), status
     return redirect(request.referrer or url_for("licencias.gestion"))
 
 

--- a/app/routes/search_api.py
+++ b/app/routes/search_api.py
@@ -1,0 +1,195 @@
+"""REST API for live search lookups."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from flask import Blueprint, abort, jsonify, request
+from flask_login import current_user, login_required
+
+from app.models import Hospital, HospitalUsuarioRol, Rol, Usuario
+from app.services.audit_service import log_action
+from app.utils.search import apply_text_search, paginate_query
+
+search_api_bp = Blueprint("search_api", __name__, url_prefix="/api/search")
+
+
+@dataclass
+class SearchResource:
+    model: type
+    columns: tuple
+    formatter: Callable[[object], dict]
+    hospital_field: object | None = None
+    extra_filters: Callable[[object], object] | None = None
+
+
+def _sanitize_page() -> tuple[int, int]:
+    page = request.args.get("page", type=int, default=1)
+    per_page = request.args.get("per_page", type=int, default=20)
+    per_page = max(1, min(per_page, 50))
+    return page, per_page
+
+
+def _apply_hospital_scope(query, field):
+    hospital_id = request.args.get("hospital_id", type=int)
+    if hospital_id:
+        return query.filter(field == hospital_id)
+
+    if not current_user.is_authenticated:
+        return query
+
+    allowed = current_user.allowed_hospital_ids()
+    if not allowed:
+        return query
+    return query.filter(field.in_(allowed))
+
+
+def _configure_resources() -> dict[str, SearchResource]:
+    return {
+        "usuarios": SearchResource(
+            model=Usuario,
+            columns=(Usuario.nombre, Usuario.apellido, Usuario.username, Usuario.email),
+            formatter=lambda usuario: {
+                "id": usuario.id,
+                "label": f"{usuario.nombre} {usuario.apellido or ''}".strip(),
+                "extra": {
+                    "email": usuario.email,
+                    "rol": usuario.rol.nombre if usuario.rol else None,
+                },
+            },
+        ),
+        "hospitales": SearchResource(
+            model=Hospital,
+            columns=(Hospital.nombre, Hospital.direccion, Hospital.codigo),
+            formatter=lambda hospital: {
+                "id": hospital.id,
+                "label": hospital.nombre,
+                "extra": {"direccion": hospital.direccion},
+            },
+        ),
+        "roles": SearchResource(
+            model=Rol,
+            columns=(Rol.nombre,),
+            formatter=lambda rol: {
+                "id": rol.id,
+                "label": rol.nombre,
+            },
+        ),
+    }
+
+
+@search_api_bp.get("/<resource>")
+@login_required
+def live_search(resource: str):
+    resources = _configure_resources()
+    config = resources.get(resource)
+    if not config:
+        abort(404)
+
+    query_value = (request.args.get("q", "") or "").strip()
+
+    query = config.model.query
+    if config.hospital_field is not None:
+        query = _apply_hospital_scope(query, config.hospital_field)
+
+    query = apply_text_search(query, config.columns, query_value)
+    if config.extra_filters:
+        query = config.extra_filters(query)
+
+    page, per_page = _sanitize_page()
+    pagination = paginate_query(query, page=page, per_page=per_page)
+    items = [config.formatter(item) for item in pagination.items]
+    return jsonify(
+        {
+            "items": items,
+            "page": pagination.page,
+            "pages": pagination.pages,
+            "total": pagination.total,
+        }
+    )
+
+
+@search_api_bp.get("/usuarios/<int:usuario_id>/hospitales")
+@login_required
+def get_usuario_hospitales(usuario_id: int):
+    if not current_user.has_role("admin", "superadmin"):
+        abort(403)
+    usuario = Usuario.query.get_or_404(usuario_id)
+    assignments = [
+        {
+            "hospital_id": rel.hospital_id,
+            "hospital": rel.hospital.nombre,
+            "rol_id": rel.rol_id,
+            "rol": rel.rol.nombre,
+        }
+        for rel in usuario.hospitales_roles
+    ]
+    return jsonify({"items": assignments})
+
+
+@search_api_bp.post("/usuarios/<int:usuario_id>/hospitales/bulk")
+@login_required
+def bulk_update_usuario_hospitales(usuario_id: int):
+    if not current_user.has_role("admin", "superadmin"):
+        abort(403)
+
+    usuario = Usuario.query.get_or_404(usuario_id)
+    payload = request.get_json(silent=True) or {}
+    desired_assignments: Iterable[dict] = payload.get("add", [])
+    desired_map: dict[int, int] = {}
+    for item in desired_assignments:
+        try:
+            hospital_id = int(item.get("hospital_id"))
+        except (TypeError, ValueError):
+            continue
+        try:
+            rol_id = int(item.get("rol_id")) if item.get("rol_id") is not None else None
+        except (TypeError, ValueError):
+            rol_id = None
+        if rol_id is None:
+            continue
+        desired_map[hospital_id] = rol_id
+
+    existing = {rel.hospital_id: rel for rel in usuario.hospitales_roles}
+
+    for hospital_id, relation in list(existing.items()):
+        if hospital_id not in desired_map:
+            usuario.hospitales_roles.remove(relation)
+
+    for hospital_id, rol_id in desired_map.items():
+        relation = existing.get(hospital_id)
+        if relation:
+            relation.rol_id = rol_id
+        else:
+            usuario.hospitales_roles.append(
+                HospitalUsuarioRol(hospital_id=hospital_id, rol_id=rol_id)
+            )
+
+    from app.extensions import db
+
+    db.session.add(usuario)
+    db.session.commit()
+
+    log_action(
+        usuario_id=current_user.id,
+        accion="asignar_hospitales",
+        modulo="usuarios",
+        entidad="Usuario",
+        entidad_id=usuario.id,
+        descripcion="Actualización masiva de asignaciones de hospitales",
+        cambios={"hospitales": list(desired_map.keys())},
+    )
+
+    assignments = [
+        {
+            "hospital_id": rel.hospital_id,
+            "hospital": rel.hospital.nombre,
+            "rol_id": rel.rol_id,
+            "rol": rel.rol.nombre,
+        }
+        for rel in usuario.hospitales_roles
+    ]
+    return jsonify({"items": assignments})
+
+
+__all__ = ["search_api_bp"]

--- a/app/routes/usuarios/routes.py
+++ b/app/routes/usuarios/routes.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 
 import secrets
 
-from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, url_for
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from flask_login import current_user, login_required
 from sqlalchemy import asc, or_
 
 from app.extensions import db
 from app.forms.usuario import UsuarioForm
-from app.models import Usuario
+from app.models import Rol, Usuario
 from app.security import require_roles
 from app.services.audit_service import log_action
 
@@ -137,3 +146,15 @@ def cambiar_estado(usuario_id: int, accion: str):
         registro_id=usuario.id,
     )
     return redirect(url_for("usuarios.listar"))
+
+
+@usuarios_bp.route("/asignacion")
+@login_required
+@require_roles("admin", "superadmin")
+def asignacion():
+    roles = Rol.query.order_by(Rol.nombre).all()
+    return render_template(
+        "usuarios/asignacion.html",
+        roles=roles,
+        usuario=None,
+    )

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -1,7 +1,6 @@
 """Audit service writing records to the database."""
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from flask import request
@@ -18,6 +17,11 @@ def log_action(
     tabla: str | None = None,
     registro_id: int | None = None,
     datos: dict[str, Any] | None = None,
+    hospital_id: int | None = None,
+    descripcion: str | None = None,
+    entidad: str | None = None,
+    entidad_id: int | None = None,
+    cambios: dict[str, Any] | None = None,
 ) -> Auditoria:
     """Persist an audit entry."""
 
@@ -25,9 +29,11 @@ def log_action(
         usuario_id=usuario_id,
         accion=accion,
         modulo=modulo,
-        tabla=tabla,
-        registro_id=registro_id,
-        datos=json.dumps(datos, ensure_ascii=False) if datos else None,
+        hospital_id=hospital_id,
+        entidad=entidad or tabla,
+        entidad_id=entidad_id or registro_id,
+        descripcion=descripcion,
+        cambios=cambios or datos,
         ip_address=request.remote_addr if request else None,
     )
     db.session.add(entry)
@@ -39,7 +45,7 @@ def get_logs(limit: int = 100) -> list[Auditoria]:
     """Return the most recent audit entries."""
 
     return (
-        Auditoria.query.order_by(Auditoria.fecha.desc()).limit(limit).all()
+        Auditoria.query.order_by(Auditoria.created_at.desc()).limit(limit).all()
     )
 
 

--- a/app/static/js/filters.js
+++ b/app/static/js/filters.js
@@ -1,0 +1,14 @@
+(function (document) {
+  document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    if (!form) {
+      return;
+    }
+    const inputs = form.querySelectorAll('input, select');
+    inputs.forEach((input) => {
+      input.addEventListener('change', () => {
+        form.requestSubmit();
+      });
+    });
+  });
+})(document);

--- a/app/static/js/live_search.js
+++ b/app/static/js/live_search.js
@@ -1,0 +1,154 @@
+(function (window, document) {
+  const DEFAULT_DEBOUNCE = 200;
+
+  function debounce(fn, wait) {
+    let timeout;
+    return function (...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+
+  function renderResults(target, items, templateFn) {
+    if (!target) {
+      return;
+    }
+    target.innerHTML = "";
+    if (!items.length) {
+      target.innerHTML = '<li class="list-group-item text-muted">Sin resultados</li>';
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    items.forEach((item) => {
+      const element = templateFn(item);
+      fragment.appendChild(element);
+    });
+    target.appendChild(fragment);
+  }
+
+  function defaultTemplate(item) {
+    const li = document.createElement("li");
+    li.className = "list-group-item list-group-item-action";
+    li.textContent = item.label;
+    li.dataset.value = item.id;
+    return li;
+  }
+
+  function attachLiveSearch(inputEl, options) {
+    const config = Object.assign(
+      {
+        minLength: 1,
+        debounce: DEFAULT_DEBOUNCE,
+        templateItem: defaultTemplate,
+        targetListEl: null,
+        resource: null,
+        extraParamsFn: null,
+        onSelect: null,
+      },
+      options || {}
+    );
+
+    const target =
+      typeof config.targetListEl === "string"
+        ? document.querySelector(config.targetListEl)
+        : config.targetListEl;
+
+    if (!inputEl || !config.resource) {
+      return () => {};
+    }
+
+    let activeIndex = -1;
+    let lastItems = [];
+
+    function moveActive(delta) {
+      if (!target) {
+        return;
+      }
+      const items = Array.from(target.querySelectorAll(".list-group-item"));
+      if (!items.length) {
+        return;
+      }
+      items.forEach((item) => item.classList.remove("active"));
+      activeIndex = (activeIndex + delta + items.length) % items.length;
+      items[activeIndex].classList.add("active");
+      items[activeIndex].scrollIntoView({ block: "nearest" });
+    }
+
+    function triggerSelect(item) {
+      if (typeof config.onSelect === "function") {
+        config.onSelect(item);
+      }
+    }
+
+    function handleKeyboard(event) {
+      if (!target || !lastItems.length) {
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        moveActive(1);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        moveActive(-1);
+      } else if (event.key === "Enter" && activeIndex >= 0) {
+        event.preventDefault();
+        triggerSelect(lastItems[activeIndex]);
+      }
+    }
+
+    function fetchResults(value) {
+      if (!value || value.length < config.minLength) {
+        if (target) {
+          target.innerHTML = "";
+        }
+        return;
+      }
+      const params = new URLSearchParams({ q: value });
+      if (typeof config.extraParamsFn === "function") {
+        const extra = config.extraParamsFn() || {};
+        Object.entries(extra).forEach(([key, val]) => {
+          if (val !== undefined && val !== null && val !== "") {
+            params.append(key, val);
+          }
+        });
+      }
+      fetch(`/api/search/${config.resource}?${params.toString()}`, {
+        headers: {
+          Accept: "application/json",
+        },
+        credentials: "same-origin",
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          lastItems = data.items || [];
+          activeIndex = -1;
+          if (target) {
+            renderResults(target, lastItems, (item) => {
+              const element = config.templateItem(item);
+              element.addEventListener("click", () => triggerSelect(item));
+              return element;
+            });
+          }
+        })
+        .catch(() => {
+          if (target) {
+            target.innerHTML = '<li class="list-group-item text-danger">Error al buscar</li>';
+          }
+        });
+    }
+
+    const debounced = debounce(fetchResults, config.debounce);
+    inputEl.addEventListener("input", (event) => {
+      const value = event.target.value;
+      debounced(value);
+    });
+    inputEl.addEventListener("keydown", handleKeyboard);
+
+    return function detach() {
+      inputEl.removeEventListener("input", debounced);
+      inputEl.removeEventListener("keydown", handleKeyboard);
+    };
+  }
+
+  window.attachLiveSearch = attachLiveSearch;
+})(window, document);

--- a/app/static/js/pickers.js
+++ b/app/static/js/pickers.js
@@ -1,0 +1,149 @@
+(function (window, document) {
+  function createChip(item, roles, onRemove, onRoleChange) {
+    const li = document.createElement("li");
+    li.className = "list-group-item d-flex align-items-center justify-content-between";
+    li.dataset.hospitalId = item.hospital_id;
+
+    const left = document.createElement("div");
+    left.innerHTML = `<strong>${item.hospital}</strong>`;
+
+    const controls = document.createElement("div");
+    controls.className = "d-flex align-items-center gap-2";
+
+    const select = document.createElement("select");
+    select.className = "form-select form-select-sm";
+    const defaultOption = document.createElement("option");
+    defaultOption.value = "";
+    defaultOption.textContent = "Seleccionar rol";
+    select.appendChild(defaultOption);
+    roles.forEach((rol) => {
+      const option = document.createElement("option");
+      option.value = String(rol.id);
+      option.textContent = rol.nombre;
+      if (item.rol_id && Number(item.rol_id) === Number(rol.id)) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    });
+    select.addEventListener("change", () => onRoleChange(item.hospital_id, select.value));
+
+    const removeBtn = document.createElement("button");
+    removeBtn.type = "button";
+    removeBtn.className = "btn btn-sm btn-outline-danger";
+    removeBtn.textContent = "Quitar";
+    removeBtn.addEventListener("click", () => onRemove(item.hospital_id));
+
+    controls.appendChild(select);
+    controls.appendChild(removeBtn);
+
+    li.appendChild(left);
+    li.appendChild(controls);
+    return li;
+  }
+
+  function UserHospitalAssignment(options) {
+    const config = Object.assign(
+      {
+        userInput: "#usuarioLookup",
+        hospitalInput: "#hospitalLookup",
+        hospitalList: "#hospitalAssignments",
+        resourceUsers: "usuarios",
+        resourceHospitals: "hospitales",
+        onUserSelected: () => {},
+        roles: [],
+      },
+      options || {}
+    );
+
+    const userInput = document.querySelector(config.userInput);
+    const hospitalInput = document.querySelector(config.hospitalInput);
+    const hospitalList = document.querySelector(config.hospitalList);
+    const state = new Map();
+
+    let currentUserId = null;
+
+    function renderHospitals(assignments) {
+      if (!hospitalList) {
+        return;
+      }
+      hospitalList.innerHTML = "";
+      assignments.forEach((item) => {
+        const node = createChip(item, config.roles, removeHospital, updateRole);
+        hospitalList.appendChild(node);
+      });
+    }
+
+    function removeHospital(hospitalId) {
+      state.delete(hospitalId);
+      renderHospitals(Array.from(state.values()));
+    }
+
+    function updateRole(hospitalId, rolId) {
+      const current = state.get(hospitalId);
+      if (current) {
+        current.rol_id = rolId ? Number(rolId) : null;
+      }
+    }
+
+    function addHospital(item) {
+      if (!item) return;
+      if (state.has(item.id)) {
+        return;
+      }
+      state.set(item.id, {
+        hospital_id: item.id,
+        hospital: item.label,
+        rol_id: null,
+      });
+      renderHospitals(Array.from(state.values()));
+      hospitalInput.value = "";
+    }
+
+    if (userInput) {
+      window.attachLiveSearch(userInput, {
+        resource: config.resourceUsers,
+        targetListEl: document.querySelector("#usuarioLookupResults"),
+        onSelect: (item) => {
+          currentUserId = item.id;
+          userInput.value = item.label;
+          if (typeof config.onUserSelected === "function") {
+            config.onUserSelected(item);
+          }
+          fetch(`/api/search/usuarios/${item.id}/hospitales`, {
+            headers: { Accept: "application/json" },
+            credentials: "same-origin",
+          })
+            .then((response) => response.json())
+            .then((data) => {
+              state.clear();
+              (data.items || []).forEach((assignment) => {
+                state.set(assignment.hospital_id, assignment);
+              });
+              renderHospitals(Array.from(state.values()));
+            });
+        },
+      });
+    }
+
+    if (hospitalInput) {
+      window.attachLiveSearch(hospitalInput, {
+        resource: config.resourceHospitals,
+        targetListEl: document.querySelector("#hospitalLookupResults"),
+        onSelect: addHospital,
+      });
+    }
+
+    return {
+      getAssignments() {
+        return Array.from(state.values());
+      },
+      getUsuarioId() {
+        return currentUserId;
+      },
+      removeHospital,
+      addHospital,
+    };
+  }
+
+  window.UserHospitalAssignment = UserHospitalAssignment;
+})(window, document);

--- a/app/templates/auditoria/index.html
+++ b/app/templates/auditoria/index.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+{% block title %}Auditoría{% endblock %}
+{% block header_title %}Auditoría{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/live_search.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/filters.js') }}"></script>
+{% endblock %}
+{% block content %}
+<form class="row g-3 mb-4" method="get">
+  <div class="col-md-4">
+    <label for="q" class="form-label">Texto</label>
+    <input type="text" class="form-control" id="q" name="q" value="{{ filtros.q }}" placeholder="Buscar en descripción, módulo o acción">
+  </div>
+  <div class="col-md-4">
+    <label for="usuario_id" class="form-label">Usuario</label>
+    <select class="form-select" id="usuario_id" name="usuario_id">
+      <option value="">Todos</option>
+      {% for usuario in usuarios %}
+        <option value="{{ usuario.id }}" {% if filtros.usuario_id == usuario.id %}selected{% endif %}>{{ usuario.nombre }}{% if usuario.apellido %} {{ usuario.apellido }}{% endif %}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-4">
+    <label for="hospital_id" class="form-label">Hospital</label>
+    <select class="form-select" id="hospital_id" name="hospital_id">
+      <option value="">Todos</option>
+      {% for hospital in hospitales %}
+        <option value="{{ hospital.id }}" {% if filtros.hospital_id == hospital.id %}selected{% endif %}>{{ hospital.nombre }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-3">
+    <label for="modulo" class="form-label">Módulo</label>
+    <input type="text" class="form-control" id="modulo" name="modulo" value="{{ filtros.modulo or '' }}">
+  </div>
+  <div class="col-md-3">
+    <label for="accion" class="form-label">Acción</label>
+    <input type="text" class="form-control" id="accion" name="accion" value="{{ filtros.accion or '' }}">
+  </div>
+  <div class="col-md-3">
+    <label for="desde" class="form-label">Desde</label>
+    <input type="date" class="form-control" id="desde" name="desde" value="{{ filtros.desde or '' }}">
+  </div>
+  <div class="col-md-3">
+    <label for="hasta" class="form-label">Hasta</label>
+    <input type="date" class="form-control" id="hasta" name="hasta" value="{{ filtros.hasta or '' }}">
+  </div>
+  <div class="col-12 text-end">
+    <button type="submit" class="btn btn-primary">Filtrar</button>
+  </div>
+</form>
+<div class="table-responsive bg-white rounded shadow-sm">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th>Fecha</th>
+        <th>Usuario</th>
+        <th>Hospital</th>
+        <th>Módulo</th>
+        <th>Acción</th>
+        <th>Entidad</th>
+        <th>Descripción</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for log in pagination.items %}
+        <tr>
+          <td>{{ log.created_at.strftime('%d/%m/%Y %H:%M') if log.created_at else '' }}</td>
+          <td>{{ log.usuario.nombre if log.usuario else 'Sistema' }}</td>
+          <td>{{ log.hospital.nombre if log.hospital else '-' }}</td>
+          <td>{{ log.modulo or '-' }}</td>
+          <td>{{ log.accion }}</td>
+          <td>{{ log.entidad or '-' }}{% if log.entidad_id %} #{{ log.entidad_id }}{% endif %}</td>
+          <td>
+            {% if log.descripcion %}
+              <span>{{ log.descripcion }}</span>
+            {% else %}
+              <code class="small">{{ log.cambios | tojson if log.cambios else '' }}</code>
+            {% endif %}
+          </td>
+        </tr>
+      {% else %}
+        <tr>
+          <td colspan="7" class="text-center text-muted py-4">Sin registros.</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% from '_pagination.html' import render_pagination %}
+{{ render_pagination(pagination) }}
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -124,7 +124,8 @@
                     <li><a class="sidebar-sublink{% if current_bp == 'usuarios' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('usuarios.listar') }}">Listado</a></li>
                     <li><a class="sidebar-sublink{% if current_endpoint == 'usuarios.crear' %} active{% endif %}" href="{{ url_for('usuarios.crear') }}">Nuevo usuario</a></li>
                     <li><a class="sidebar-sublink{% if current_bp == 'permisos' and 'listar' in current_endpoint %} active{% endif %}" href="{{ url_for('permisos.listar') }}">Permisos</a></li>
-                    <li><a class="sidebar-sublink{% if current_bp == 'permisos' and 'auditorias' in current_endpoint %} active{% endif %}" href="{{ url_for('permisos.listar') }}">Auditorías</a></li>
+                    <li><a class="sidebar-sublink{% if current_bp == 'auditoria' %} active{% endif %}" href="{{ url_for('auditoria.index') }}">Auditorías</a></li>
+                    <li><a class="sidebar-sublink{% if current_endpoint == 'usuarios.asignacion' %} active{% endif %}" href="{{ url_for('usuarios.asignacion') }}">Asignación hospitales</a></li>
                     <li><a class="sidebar-sublink{% if current_bp == 'licencias' %} active{% endif %}" href="{{ url_for('licencias.gestion') }}">Licencias (gestión)</a></li>
                   </ul>
                 </div>

--- a/app/templates/partials/_chips.html
+++ b/app/templates/partials/_chips.html
@@ -1,0 +1,1 @@
+<ul id="hospitalAssignments" class="list-group"></ul>

--- a/app/templates/partials/_picker.html
+++ b/app/templates/partials/_picker.html
@@ -1,0 +1,11 @@
+<div class="picker mb-3">
+  <label class="form-label" for="{{ id }}">{{ label }}</label>
+  <input
+    type="text"
+    id="{{ id }}"
+    class="form-control"
+    placeholder="{{ placeholder | default('') }}"
+    autocomplete="off"
+  />
+  <ul id="{{ id }}Results" class="list-group mt-2"></ul>
+</div>

--- a/app/templates/usuarios/asignacion.html
+++ b/app/templates/usuarios/asignacion.html
@@ -1,0 +1,81 @@
+{% extends 'base.html' %}
+{% from '_pagination.html' import render_pagination %}
+{% block title %}Asignación de hospitales{% endblock %}
+{% block header_title %}Asignación de hospitales{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/live_search.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/pickers.js') }}"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const roles = {{ roles|tojson }};
+      const manager = window.UserHospitalAssignment({
+        onUserSelected: function (item) {
+          const form = document.querySelector('#asignacionForm');
+          if (form) {
+            form.dataset.usuarioId = item.id;
+          }
+        },
+        roles: roles
+      });
+      const form = document.querySelector('#asignacionForm');
+      if (!form) return;
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        const usuarioId = manager.getUsuarioId();
+        if (!usuarioId) {
+          alert('Seleccione un usuario antes de guardar.');
+          return;
+        }
+        const assignments = manager.getAssignments();
+        if (!assignments.length) {
+          alert('Agregue al menos un hospital.');
+          return;
+        }
+        const pendientes = assignments.filter((item) => !item.rol_id);
+        if (pendientes.length) {
+          alert('Seleccione un rol para cada hospital asignado.');
+          return;
+        }
+        fetch(`/api/search/usuarios/${usuarioId}/hospitales/bulk`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-CSRFToken': '{{ csrf_token() }}'
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ add: assignments })
+        })
+          .then((response) => response.json())
+          .then(() => {
+            const alert = document.createElement('div');
+            alert.className = 'alert alert-success mt-3';
+            alert.textContent = 'Asignaciones guardadas correctamente';
+            form.appendChild(alert);
+            setTimeout(() => alert.remove(), 4000);
+          });
+      });
+    });
+  </script>
+{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col-lg-6">
+    {% include 'partials/_picker.html' with id='usuarioLookup', label='Usuario', placeholder='Buscar usuario...' %}
+  </div>
+</div>
+<div class="row">
+  <div class="col-lg-6">
+    {% include 'partials/_picker.html' with id='hospitalLookup', label='Hospital', placeholder='Buscar hospital...' %}
+  </div>
+</div>
+<form id="asignacionForm" data-usuario-id="{{ usuario.id if usuario else '' }}">
+  <h5 class="mt-4">Hospitales asignados</h5>
+  <p class="text-muted">Seleccione un usuario y luego agregue hospitales utilizando el buscador.</p>
+  {% include 'partials/_chips.html' %}
+  <div class="mt-3">
+    <button type="submit" class="btn btn-primary">Guardar asignaciones</button>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/usuarios/listar.html
+++ b/app/templates/usuarios/listar.html
@@ -16,6 +16,7 @@
       </div>
       <div class="ms-auto align-self-end">
         <a class="btn btn-success" href="{{ url_for('usuarios.crear') }}">Nuevo usuario</a>
+        <a class="btn btn-outline-primary ms-2" href="{{ url_for('usuarios.asignacion') }}">Asignación hospitales</a>
       </div>
     </form>
   </div>

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -1,0 +1,77 @@
+"""Helpers for building adaptive text search queries."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from sqlalchemy import ColumnElement, func, literal, or_, select
+from sqlalchemy.orm import Query
+
+from app.extensions import db
+
+
+def _is_postgres() -> bool:
+    bind = db.session.get_bind()  # type: ignore[arg-type]
+    if not bind:
+        return False
+    return bind.dialect.name == "postgresql"
+
+
+def _coalesce_concat(columns: Sequence[ColumnElement[str]]) -> ColumnElement[str]:
+    values: list[ColumnElement[str]] = [func.coalesce(col, literal("")) for col in columns]
+    return func.concat_ws(literal(" "), *values)
+
+
+def build_text_search(columns: Sequence[ColumnElement[str]], term: str) -> ColumnElement[bool]:
+    """Return a SQL expression that matches ``term`` across ``columns``."""
+
+    sanitized = (term or "").strip()
+    if not sanitized:
+        raise ValueError("term must be a non-empty string")
+
+    if _is_postgres() and len(sanitized) >= 3:
+        vector = func.to_tsvector("spanish", _coalesce_concat(columns))
+        query = func.plainto_tsquery("spanish", sanitized)
+        return vector.op("@@")(query)
+
+    like = f"%{sanitized}%"
+    return or_(*[col.ilike(like) for col in columns])
+
+
+def apply_text_search(query: Query, columns: Sequence[ColumnElement[str]], term: str) -> Query:
+    """Apply a flexible text search filter to ``query``."""
+
+    sanitized = (term or "").strip()
+    if not sanitized:
+        return query
+    try:
+        condition = build_text_search(columns, sanitized)
+    except ValueError:
+        return query
+    return query.filter(condition)
+
+
+def paginate_query(query: Query, *, page: int, per_page: int):
+    """Paginate ``query`` enforcing sane defaults."""
+
+    page = max(page, 1)
+    per_page = max(1, min(per_page, 100))
+    return query.paginate(page=page, per_page=per_page, error_out=False)
+
+
+def search_lookup(model, columns: Sequence[ColumnElement[str]], term: str, limit: int = 10):
+    """Return a list of model instances matching ``term`` limited to ``limit``."""
+
+    query = select(model)
+    sanitized = (term or "").strip()
+    if sanitized:
+        query = query.filter(build_text_search(columns, sanitized))
+    query = query.order_by(columns[0]).limit(limit)
+    return db.session.execute(query).scalars().all()
+
+
+__all__ = [
+    "apply_text_search",
+    "build_text_search",
+    "paginate_query",
+    "search_lookup",
+]

--- a/migrations/versions/1234abcd5678_live_search_assignments.py
+++ b/migrations/versions/1234abcd5678_live_search_assignments.py
@@ -1,0 +1,109 @@
+"""Search helpers, hospital assignments and audit improvements."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "1234abcd5678"
+down_revision = "2f1a4b2b1234"
+branch_labels = None
+depends_on = None
+
+
+def _is_postgres(connection) -> bool:
+    return connection.dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Enable extensions for advanced text search on PostgreSQL.
+    if _is_postgres(bind):
+        bind.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        bind.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+
+    # Create association table for usuario/hospital assignments.
+    op.create_table(
+        "hospital_usuario_rol",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("usuario_id", sa.Integer(), sa.ForeignKey("usuarios.id"), nullable=False),
+        sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id"), nullable=False),
+        sa.Column("rol_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.UniqueConstraint("usuario_id", "hospital_id", name="uq_usuario_hospital_asignacion"),
+    )
+
+    if "auditoria" in inspector.get_table_names():
+        op.rename_table("auditoria", "auditorias")
+        inspector = inspect(bind)
+
+    columns = {col["name"]: col for col in inspector.get_columns("auditorias")}
+
+    if "tabla" in columns:
+        op.drop_column("auditorias", "tabla")
+    if "registro_id" in columns:
+        op.drop_column("auditorias", "registro_id")
+    if "datos" in columns:
+        op.drop_column("auditorias", "datos")
+    if "fecha" in columns:
+        op.alter_column("auditorias", "fecha", new_column_name="created_at")
+
+    if "hospital_id" not in columns:
+        op.add_column("auditorias", sa.Column("hospital_id", sa.Integer(), sa.ForeignKey("hospitales.id")))
+    if "entidad" not in columns:
+        op.add_column("auditorias", sa.Column("entidad", sa.String(length=50)))
+    if "entidad_id" not in columns:
+        op.add_column("auditorias", sa.Column("entidad_id", sa.Integer()))
+    if "descripcion" not in columns:
+        op.add_column("auditorias", sa.Column("descripcion", sa.Text()))
+    if "cambios" not in columns:
+        op.add_column("auditorias", sa.Column("cambios", sa.JSON()))
+
+    op.create_index("ix_auditorias_usuario", "auditorias", ["usuario_id"])
+    op.create_index("ix_auditorias_hospital", "auditorias", ["hospital_id"])
+    op.create_index("ix_auditorias_modulo", "auditorias", ["modulo"])
+    op.create_index("ix_auditorias_accion", "auditorias", ["accion"])
+    op.create_index("ix_auditorias_created_at", "auditorias", ["created_at"])
+
+    if _is_postgres(bind):
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_usuarios_search ON usuarios
+            USING gin (to_tsvector('spanish', coalesce(nombre,'') || ' ' || coalesce(apellido,'') || ' ' || coalesce(username,'') || ' ' || coalesce(email,'')));
+            """
+        )
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_hospitales_search ON hospitales
+            USING gin (to_tsvector('spanish', coalesce(nombre,'') || ' ' || coalesce(direccion,'') || ' ' || coalesce(codigo,'')));
+            """
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("DROP INDEX IF EXISTS ix_hospitales_search")
+        op.execute("DROP INDEX IF EXISTS ix_usuarios_search")
+
+    op.drop_index("ix_auditorias_created_at", table_name="auditorias")
+    op.drop_index("ix_auditorias_accion", table_name="auditorias")
+    op.drop_index("ix_auditorias_modulo", table_name="auditorias")
+    op.drop_index("ix_auditorias_hospital", table_name="auditorias")
+    op.drop_index("ix_auditorias_usuario", table_name="auditorias")
+
+    op.drop_column("auditorias", "cambios")
+    op.drop_column("auditorias", "descripcion")
+    op.drop_column("auditorias", "entidad_id")
+    op.drop_column("auditorias", "entidad")
+    op.drop_column("auditorias", "hospital_id")
+
+    op.alter_column("auditorias", "created_at", new_column_name="fecha")
+    op.add_column("auditorias", sa.Column("datos", sa.Text()))
+    op.add_column("auditorias", sa.Column("registro_id", sa.Integer()))
+    op.add_column("auditorias", sa.Column("tabla", sa.String(length=100)))
+
+    op.rename_table("auditorias", "auditoria")
+
+    op.drop_table("hospital_usuario_rol")


### PR DESCRIPTION
## Summary
- add a hospital/usuario/rol association model, hook it into existing relationships, and expose a bulk assignment UI with live pickers
- introduce reusable text-search helpers, a unified /api/search endpoint, and client-side utilities for live lookup widgets
- expand the auditing stack with richer fields, filtered views, and asynchronous licence state responses together with supporting migrations and indexes

## Testing
- `pytest` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68db13da52408324854c2a500db08df9