### PR TITLE
Add PowerShell helper to run Flask server on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run test
+.PHONY: install run test run-windows
 
 install:
 	pip install -r requirements.txt
@@ -8,3 +8,6 @@ run:
 
 test:
 	pytest
+
+run-windows:
+	pwsh -File scripts/run_server.ps1

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ export FLASK_RUN_PORT=5000         # ajustar si se usa otro puerto
 # Windows: permitir el puerto 5000/seleccionado en el Firewall
 ```
 
+> **Nota (Windows):** Podés usar `.\scripts\run_server.ps1 [-Host 0.0.0.0] [-Port 5000] [-Debug]` para configurar el entorno y lanzar el servidor con PowerShell.
+
 ### 5.3 Con Docker
 
 Requiere Docker y Docker Compose.

--- a/scripts/run_server.ps1
+++ b/scripts/run_server.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Host,
+
+    [Parameter()]
+    [int]$Port,
+
+    [switch]$Debug
+)
+
+$projectRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$originalLocation = Get-Location
+Set-Location $projectRoot
+
+try {
+    $venvActivate = Join-Path (Join-Path $projectRoot '.venv') 'Scripts/Activate.ps1'
+    if (Test-Path $venvActivate) {
+        Write-Host "Activating virtual environment from $venvActivate" -ForegroundColor Cyan
+        . $venvActivate
+    }
+
+    if (-not $env:FLASK_APP) {
+        $env:FLASK_APP = 'wsgi.py'
+        Write-Host "FLASK_APP not set. Defaulting to $($env:FLASK_APP)." -ForegroundColor Yellow
+    }
+
+    $flaskArgs = @('run')
+
+    if ($Host) {
+        $flaskArgs += @('--host', $Host)
+    }
+
+    if ($Port) {
+        $flaskArgs += @('--port', $Port.ToString())
+    }
+
+    if ($Debug.IsPresent) {
+        $flaskArgs += '--debug'
+    }
+
+    Write-Host "Running: flask $($flaskArgs -join ' ')" -ForegroundColor Green
+    & flask @flaskArgs
+}
+finally {
+    Set-Location $originalLocation
+}


### PR DESCRIPTION
## Summary
- add a PowerShell helper script that activates the virtual environment, sets FLASK_APP when missing, and forwards host/port/debug options to `flask run`
- document how to use the PowerShell helper when running the project without Docker
- add a Makefile target that invokes the PowerShell helper for Windows users

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68db27ea8d0c83249ccb93d7d921e7e7