### PR TITLE
Prepare local SQLite development workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,3 @@
 FLASK_APP=wsgi.py
 FLASK_ENV=development
-FLASK_RUN_HOST=0.0.0.0
-FLASK_RUN_PORT=5000
-SECRET_KEY=change_me
-# Si se deja vacío, por defecto SQLite para desarrollo:
-# SQLALCHEMY_DATABASE_URI=postgresql://usuario:pass@localhost/inventario_hospital
-AUTO_SEED_ON_START=1
-DEMO_SEED_VERBOSE=1
-UPLOAD_FOLDER=./uploads
-DOCSCAN_FOLDER=./uploads/docscan
-DEFAULT_PAGE_SIZE=20
-LOG_LEVEL=INFO
+SQLALCHEMY_DATABASE_URI=sqlite:///inventario.db

--- a/README.md
+++ b/README.md
@@ -4,26 +4,15 @@ Sistema web completo y listo para producción para la gestión de inventario hos
 
 ## Windows 11 – Arranque rápido
 
-1. **Doble clic en `scripts/bootstrap.bat` y seguí los prompts.** No hace falta abrir PowerShell manualmente; el `.bat` ejecuta el flujo completo con `-ExecutionPolicy Bypass`.
-2. **¿Qué hace el script automáticamente?**
-   - Detecta la raíz del proyecto aunque la ruta contenga espacios.
-   - Verifica que exista Python 3.11+ y muestra un enlace de descarga si falta.
-   - Crea y activa `.venv` (si ya existe lo reutiliza) y usa siempre `.\.venv\Scripts\python.exe -m pip ...`.
-   - Actualiza `pip`, instala `requirements.txt` y, si `psycopg2` falla, instala `psycopg2-binary` como fallback.
-   - Crea `.env` cuando falta solicitando los datos por `Read-Host` y muestra los valores existentes cuando ya está configurado.
-   - Valida la conexión a PostgreSQL con `psycopg2`, ofrece crear la base si no existe y detiene el proceso con mensajes claros ante errores.
-   - Ejecuta `python -m flask db heads`, mergea múltiples heads si es necesario y aplica `python -m flask db upgrade`.
-   - Corre `python -m seeds.seed` (idempotente) para poblar usuarios, hospitales, etc.
-   - Lanza `python -m flask run --host=127.0.0.1 --port=5000 --debug` y abre el navegador en `http://127.0.0.1:5000`.
-3. **Valores por defecto de `.env` (enter para aceptar):**
-   - Host: `localhost`
-   - Base de datos: `inventario_hospital`
-   - Usuario: `salud`
-   - Password: `Catrilo.20`
-   - El script genera además `FLASK_APP=wsgi.py` y `FLASK_ENV=development`.
-   - Podés editar `.env` manualmente o borrar el archivo y volver a ejecutar el bootstrap para reconfigurar.
-4. **Primer usuario disponible después del seed:** `admin / 123456` (Superadmin).
-5. **Rearranque rápido:** una vez provisionado, usá `scripts/run_server.ps1` para iniciar solo el servidor (activa `.venv`, lee `.env`, valida PostgreSQL y ejecuta `python -m flask run --debug`).
+1. **Descargá el ZIP del repositorio y descomprimilo en tu carpeta de trabajo.**
+2. **Doble clic sobre `run_dev.ps1` (o clic derecho → “Ejecutar con PowerShell”).** El script crea el entorno virtual, instala dependencias, aplica migraciones y carga el seed de demo.
+3. **Abrí <http://127.0.0.1:5000> en el navegador.** Credenciales iniciales: usuario `admin`, contraseña `123456`.
+
+> Si PowerShell bloquea la ejecución de scripts, ejecutá una vez en una consola:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+> ```
 
 ## Tabla de contenido
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,8 @@ from flask_migrate import CommandError, merge as migrate_merge, upgrade as migra
 from sqlalchemy import inspect, select
 from sqlalchemy.orm import joinedload
 
+from dotenv import load_dotenv
+
 from config import Config
 from app.assets import ensure_favicon
 from app.extensions import configure_logging, db, init_extensions, login_manager
@@ -104,6 +106,7 @@ def _register_cli(app: Flask) -> None:
 def create_app(config_class: type[Config] | Config = Config) -> Flask:
     """Create and configure a fully featured Flask application."""
 
+    load_dotenv()
     app = Flask(__name__, instance_relative_config=False)
     if isinstance(config_class, type):
         app.config.from_object(config_class)
@@ -248,6 +251,10 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
 
     _register_cli(app)
 
+    from app.cli import seed_demo
+
+    app.cli.add_command(seed_demo)
+
     @app.errorhandler(401)
     def unauthorized(error):  # type: ignore[override]
         return render_template("errors/401.html"), 401
@@ -259,6 +266,68 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     @app.errorhandler(404)
     def not_found(error):  # type: ignore[override]
         return render_template("errors/404.html"), 404
+
+    from app.models import (
+        Acta,
+        ActaItem,
+        Adjunto,
+        Auditoria,
+        Docscan,
+        Equipo,
+        EquipoAdjunto,
+        EquipoHistorial,
+        EstadoEquipo,
+        Hospital,
+        HospitalUsuarioRol,
+        Insumo,
+        InsumoMovimiento,
+        Licencia,
+        Modulo,
+        MovimientoTipo,
+        Oficina,
+        Permiso,
+        Rol,
+        Servicio,
+        TipoActa,
+        TipoAdjunto,
+        TipoDocscan,
+        TipoEquipo,
+        TipoLicencia,
+        Usuario,
+        EstadoLicencia,
+        equipo_insumos,
+    )
+
+    _ = (
+        Acta,
+        ActaItem,
+        Adjunto,
+        Auditoria,
+        Docscan,
+        Equipo,
+        EquipoAdjunto,
+        EquipoHistorial,
+        EstadoEquipo,
+        Hospital,
+        HospitalUsuarioRol,
+        Insumo,
+        InsumoMovimiento,
+        Licencia,
+        Modulo,
+        MovimientoTipo,
+        Oficina,
+        Permiso,
+        Rol,
+        Servicio,
+        TipoActa,
+        TipoAdjunto,
+        TipoDocscan,
+        TipoEquipo,
+        TipoLicencia,
+        Usuario,
+        EstadoLicencia,
+        equipo_insumos,
+    )
 
     return app
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,55 @@
+"""Custom Flask CLI commands for local development utilities."""
+from __future__ import annotations
+
+import click
+from datetime import datetime
+
+from flask.cli import with_appcontext
+
+from app import db
+from app.models import Hospital, Oficina, Rol, Servicio, Usuario
+
+
+@click.command("seed-demo")
+@with_appcontext
+def seed_demo() -> None:
+    """Populate the database with a minimal demo dataset."""
+
+    rol = Rol.query.filter_by(nombre="Superadmin").first()
+    if not rol:
+        rol = Rol(
+            nombre="Superadmin",
+            descripcion="Rol con todos los permisos",
+            created_at=datetime.utcnow(),
+        )
+        db.session.add(rol)
+        db.session.flush()
+
+    hosp = Hospital.query.first()
+    if not hosp:
+        hosp = Hospital(nombre="Hospital Demo")
+        db.session.add(hosp)
+        db.session.flush()
+
+    u = Usuario.query.filter_by(username="admin").first()
+    if not u:
+        u = Usuario(
+            username="admin",
+            nombre="Admin",
+            dni="00000000",
+            apellido="Demo",
+            email="admin@example.com",
+            activo=True,
+            rol_id=rol.id,
+            hospital_id=hosp.id,
+        )
+        u.set_password("123456")
+        db.session.add(u)
+
+    db.session.commit()
+    print("OK: seed de demo cargado. Usuario admin / 123456")
+
+
+# Referencias silenciosas para evitar advertencias de importaciones no utilizadas
+# cuando herramientas estáticas analizan el módulo.
+_ = (Servicio, Oficina)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -41,7 +41,13 @@ if config.config_file_name is not None:  # pragma: no cover - configuration hook
 
 
 def _database_url() -> str:
-    return Config.SQLALCHEMY_DATABASE_URI
+    uri = Config.SQLALCHEMY_DATABASE_URI
+    if uri.startswith("sqlite:///") and not uri.startswith("sqlite:////"):
+        database_name = uri.split("sqlite:///", 1)[1]
+        instance_path = PROJECT_ROOT / "instance"
+        instance_path.mkdir(exist_ok=True)
+        return f"sqlite:///{(instance_path / database_name).resolve()}"
+    return uri
 
 
 def _common_config_kwargs(url: str | URL) -> dict[str, Any]:

--- a/run_dev.ps1
+++ b/run_dev.ps1
@@ -1,0 +1,39 @@
+Param(
+  [string]$Python="py"
+)
+
+$ErrorActionPreference = "Stop"
+Write-Host "== Inventario Hospital :: setup y arranque =="
+
+# 1) venv
+if (-not (Test-Path ".\.venv")) {
+  Write-Host "Creando venv..."
+  & $Python -m venv .venv
+}
+Write-Host "Activando venv..."
+. .\.venv\Scripts\Activate.ps1
+
+# 2) pip up + deps
+Write-Host "Actualizando pip..."
+python -m pip install --upgrade pip
+Write-Host "Instalando dependencias..."
+python -m pip install -r requirements.txt
+
+# 3) Variables de entorno (si no existen en el ambiente actual)
+if (-not $env:FLASK_APP) { $env:FLASK_APP = "wsgi.py" }
+if (-not $env:FLASK_ENV) { $env:FLASK_ENV = "development" }
+if (-not $env:SQLALCHEMY_DATABASE_URI -and $env:FLASK_ENV -eq "development") {
+  $env:SQLALCHEMY_DATABASE_URI = "sqlite:///inventario.db"
+}
+
+# 4) Migraciones
+Write-Host "Aplicando migraciones..."
+flask db upgrade
+
+# 5) Seed demo (idempotente)
+Write-Host "Cargando datos de demo..."
+flask seed-demo
+
+# 6) Levantar server
+Write-Host "Levantando servidor en http://127.0.0.1:5000 ..."
+flask run --host=127.0.0.1 --port=5000


### PR DESCRIPTION
## Summary
- default the development configuration to SQLite via python-dotenv and keep production validation strict
- register the new seed-demo CLI, import all models for migrations, and add a PowerShell bootstrap script for Windows
- refresh developer docs and the example .env for the new workflow

## Testing
- flask db upgrade
- flask seed-demo

------
https://chatgpt.com/codex/tasks/task_e_68dd547a0fac8324a8d7eab4770fe56d