### PR TITLE
Add Windows bootstrap scripts and superadmin CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,27 @@ Sistema web completo y listo para producción para la gestión de inventario hos
 
 ## Windows 11 – Arranque rápido
 
-1. **Descargá el ZIP del repositorio y descomprimilo en tu carpeta de trabajo.**
-2. **Doble clic sobre `run_dev.ps1` (o clic derecho → “Ejecutar con PowerShell”).** El script crea el entorno virtual, instala dependencias, aplica migraciones y carga el seed de demo.
-3. **Abrí <http://127.0.0.1:5000> en el navegador.** Credenciales iniciales: usuario `admin`, contraseña `123456`.
+1. Abrí **PowerShell** dentro de la carpeta del proyecto (`Shift` + clic derecho → “Abrir terminal PowerShell aquí”).
+2. Solo la primera vez en tu usuario de Windows ejecutá:
 
-> Si PowerShell bloquea la ejecución de scripts, ejecutá una vez en una consola:
->
-> ```powershell
-> Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
-> ```
+   ```powershell
+   Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+   ```
+
+3. Lanzá el entorno de desarrollo con:
+
+   ```powershell
+   .\scripts\run_dev.ps1
+   ```
+
+   El script crea `.venv`, instala dependencias, aplica migraciones y corre `flask seed demo` si la base `inventario.db` no existe.
+
+4. Ingresá a <http://127.0.0.1:5000>. Usuario demo listo: **admin / 123456**.
+5. Para promocionar otro usuario al rol Superadmin (por ejemplo `fpla`):
+
+   ```powershell
+   .\scripts\grant_superadmin.ps1 -Username fpla
+   ```
 
 ## Tabla de contenido
 
@@ -54,7 +66,7 @@ Sistema web completo y listo para producción para la gestión de inventario hos
 
 ## 2. Alcance funcional
 
-- Autenticación y roles: Superadmin, Admin, Técnico y Lectura. Usuario inicial: `admin / 123456` (Superadmin). Otros usuarios de ejemplo se crean con `flask demo-seed --force`.
+- Autenticación y roles: Superadmin, Admin, Técnico y Lectura. Usuario inicial: `admin / 123456` (Superadmin). Otros usuarios de ejemplo se crean con `flask seed demo`.
 - Permisos granulares por hospital y módulo (inventario, insumos, actas, adjuntos, docscan, reportes, auditoría, licencias).
 - Ubicaciones jerárquicas: Hospital → Servicio → Oficina (ABM, validaciones de duplicados, edición sin cambiar IDs).
 - Equipos: tipos predefinidos, estados (Operativo, En Servicio Técnico, De baja), expediente/año opcionales, historial.
@@ -171,8 +183,8 @@ flask db upgrade
 # 4) Arrancar (carga auto-seed si la base está vacía y AUTO_SEED_ON_START=1)
 flask run --host=127.0.0.1 --port=5000 --debug
 
-# 5) (opcional) Forzar demo seed manual
-flask demo-seed --force
+# 5) (opcional) Cargar datos de demo manualmente
+flask seed demo
 ```
 
 > Para Linux/macOS usá `python3 -m venv .venv`, `source .venv/bin/activate`, `cp .env.example .env` y los equivalentes para `export`.
@@ -215,7 +227,7 @@ flask db upgrade
 
 El repositorio incluye una migración inicial con todas las tablas declaradas en `app/models`. El comando `flask dbsafe-upgrade` toma la URI configurada en `SQLALCHEMY_DATABASE_URI`, detecta múltiples heads de Alembic, realiza un merge automático si es necesario y deja la base migrada.
 
-Seeds (`flask demo-seed` o auto-seed en desarrollo): reutiliza la aplicación Flask (misma configuración `.env`), verifica la conexión configurada (SQLite o PostgreSQL) y carga los catálogos de manera idempotente:
+Seeds (`flask seed demo` o auto-seed en desarrollo): reutiliza la aplicación Flask (misma configuración `.env`), verifica la conexión configurada (SQLite o PostgreSQL) y carga los catálogos de manera idempotente:
 
 - `admin / 123456` (Superadmin global)
 - `admin_molas / Cambiar123!` y `admin_favaloro / Cambiar123!` (Admins locales)
@@ -226,7 +238,7 @@ Seeds (`flask demo-seed` o auto-seed en desarrollo): reutiliza la aplicación Fl
 
 ### 6.1 Primer arranque
 
-En desarrollo, si no configurás `SQLALCHEMY_DATABASE_URI`, el proyecto crea `inventario.db` (SQLite) junto al código y ejecuta el seed automáticamente en el primer `flask run` cuando `AUTO_SEED_ON_START=1`. Para usar PostgreSQL definí la URI correspondiente antes de correr las migraciones (`flask db upgrade`) o ejecutar `flask demo-seed`.
+En desarrollo, si no configurás `SQLALCHEMY_DATABASE_URI`, el proyecto crea `inventario.db` (SQLite) junto al código y ejecuta el seed automáticamente en el primer `flask run` cuando `AUTO_SEED_ON_START=1`. Para usar PostgreSQL definí la URI correspondiente antes de correr las migraciones (`flask db upgrade`) o ejecutar `flask seed demo`.
 
 ## 7. Roles, permisos y seguridad
 
@@ -352,6 +364,9 @@ Casos clave:
 
 ## 14. Troubleshooting
 
+- **PowerShell bloquea scripts (.ps1):** ejecutá `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` una única vez en PowerShell y volvé a correr `./scripts/run_dev.ps1`.
+- **Python/pip no encontrados:** asegurate de que `python` esté en el PATH. Si pip falta, corré `python -m ensurepip --upgrade` y luego `python -m pip install --upgrade pip`.
+- **SQLite no disponible:** verificá que tu instalación de Python incluya el módulo `sqlite3` (en Windows 11 viene por defecto). Si la biblioteca DLL no está presente instalá el feature opcional de Windows “SQLite” o reinstalá Python seleccionando *Install for all users*.
 - **psycopg2 o conexión fallida:** verificar `SQLALCHEMY_DATABASE_URI`, credenciales y que Postgres esté levantado.
 - **Migraciones:**
   - Con el repositorio tal como viene alcanza con `flask dbsafe-upgrade`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -251,9 +251,9 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
 
     _register_cli(app)
 
-    from app.cli import seed_demo
+    from app.cli import register_commands
 
-    app.cli.add_command(seed_demo)
+    register_commands(app)
 
     @app.errorhandler(401)
     def unauthorized(error):  # type: ignore[override]

--- a/app/templates/partials/_macros.html
+++ b/app/templates/partials/_macros.html
@@ -1,0 +1,5 @@
+{% from 'partials/_picker.html' import picker as _picker %}
+
+{% macro picker(id, label, placeholder='') %}
+  {{ _picker(id, label, placeholder)|safe }}
+{% endmacro %}

--- a/app/templates/partials/_picker.html
+++ b/app/templates/partials/_picker.html
@@ -1,3 +1,4 @@
+{% macro picker(id, label, placeholder='') %}
 <div class="picker mb-3">
   <label class="form-label" for="{{ id }}">{{ label }}</label>
   <input
@@ -9,3 +10,4 @@
   />
   <ul id="{{ id }}Results" class="list-group mt-2"></ul>
 </div>
+{% endmacro %}

--- a/app/templates/usuarios/asignacion.html
+++ b/app/templates/usuarios/asignacion.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% from '_pagination.html' import render_pagination %}
+{% from 'partials/_macros.html' import picker %}
 {% block title %}Asignación de hospitales{% endblock %}
 {% block header_title %}Asignación de hospitales{% endblock %}
 {% block scripts %}
@@ -62,12 +63,12 @@
 {% block content %}
 <div class="row">
   <div class="col-lg-6">
-    {% include 'partials/_picker.html' with id='usuarioLookup', label='Usuario', placeholder='Buscar usuario...' %}
+    {{ picker('usuarioLookup', 'Usuario', 'Buscar usuario...') }}
   </div>
 </div>
 <div class="row">
   <div class="col-lg-6">
-    {% include 'partials/_picker.html' with id='hospitalLookup', label='Hospital', placeholder='Buscar hospital...' %}
+    {{ picker('hospitalLookup', 'Hospital', 'Buscar hospital...') }}
   </div>
 </div>
 <form id="asignacionForm" data-usuario-id="{{ usuario.id if usuario else '' }}">

--- a/run_dev.ps1
+++ b/run_dev.ps1
@@ -1,39 +1,7 @@
 Param(
-  [string]$Python="py"
+  [string]$Python = "python"
 )
 
-$ErrorActionPreference = "Stop"
-Write-Host "== Inventario Hospital :: setup y arranque =="
-
-# 1) venv
-if (-not (Test-Path ".\.venv")) {
-  Write-Host "Creando venv..."
-  & $Python -m venv .venv
-}
-Write-Host "Activando venv..."
-. .\.venv\Scripts\Activate.ps1
-
-# 2) pip up + deps
-Write-Host "Actualizando pip..."
-python -m pip install --upgrade pip
-Write-Host "Instalando dependencias..."
-python -m pip install -r requirements.txt
-
-# 3) Variables de entorno (si no existen en el ambiente actual)
-if (-not $env:FLASK_APP) { $env:FLASK_APP = "wsgi.py" }
-if (-not $env:FLASK_ENV) { $env:FLASK_ENV = "development" }
-if (-not $env:SQLALCHEMY_DATABASE_URI -and $env:FLASK_ENV -eq "development") {
-  $env:SQLALCHEMY_DATABASE_URI = "sqlite:///inventario.db"
-}
-
-# 4) Migraciones
-Write-Host "Aplicando migraciones..."
-flask db upgrade
-
-# 5) Seed demo (idempotente)
-Write-Host "Cargando datos de demo..."
-flask seed-demo
-
-# 6) Levantar server
-Write-Host "Levantando servidor en http://127.0.0.1:5000 ..."
-flask run --host=127.0.0.1 --port=5000
+$script = Join-Path $PSScriptRoot "scripts\run_dev.ps1"
+Write-Host "Este script fue movido a $script" -ForegroundColor Yellow
+& $script -Python $Python

--- a/scripts/grant_superadmin.ps1
+++ b/scripts/grant_superadmin.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Username
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Resolve-Path (Join-Path $scriptDir "..")
+Set-Location $projectRoot
+
+$venvPath = Join-Path $projectRoot ".venv"
+$activateScript = Join-Path $venvPath "Scripts\Activate.ps1"
+
+if (-not (Test-Path $activateScript)) {
+    Write-Host "No se encontró el entorno virtual. Ejecute primero .\\scripts\\run_dev.ps1" -ForegroundColor Yellow
+    exit 1
+}
+
+try {
+    . $activateScript
+    if (-not $env:FLASK_APP) { $env:FLASK_APP = "wsgi.py" }
+    if (-not $env:FLASK_ENV) { $env:FLASK_ENV = "development" }
+
+    Write-Host "Promoviendo usuario '$Username' al rol Superadmin..." -ForegroundColor Cyan
+    flask promote-superadmin --username $Username
+    Write-Host "Operación finalizada." -ForegroundColor Green
+}
+catch {
+    Write-Error $_.Exception.Message
+    Write-Host "Asegúrese de que el servidor se haya inicializado al menos una vez con scripts\\run_dev.ps1." -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+param(
+    [string]$Python = "python"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "== Inventario Hospital :: setup y arranque ==" -ForegroundColor Cyan
+Write-Host "Si PowerShell bloquea el script ejecute: Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Yellow
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Resolve-Path (Join-Path $scriptDir "..")
+Set-Location $projectRoot
+
+try {
+    if (-not (Get-Command $Python -ErrorAction SilentlyContinue)) {
+        throw [System.Management.Automation.CommandNotFoundException]::new("No se encontró '$Python'. Instale Python 3 y agrégelo al PATH.")
+    }
+
+    $venvPath = Join-Path $projectRoot ".venv"
+    if (-not (Test-Path $venvPath)) {
+        Write-Host "Creando entorno virtual en $venvPath ..." -ForegroundColor Cyan
+        & $Python -m venv $venvPath
+    } else {
+        Write-Host "Usando entorno virtual existente ($venvPath)." -ForegroundColor DarkGray
+    }
+
+    $activateScript = Join-Path $venvPath "Scripts\Activate.ps1"
+    if (-not (Test-Path $activateScript)) {
+        throw "No se encontró el script de activación ($activateScript). Revise la instalación de Python."
+    }
+
+    Write-Host "Activando entorno virtual..." -ForegroundColor Cyan
+    . $activateScript
+
+    Write-Host "Verificando pip..." -ForegroundColor Cyan
+    try {
+        python -m pip --version | Out-Null
+    } catch {
+        Write-Warning "pip no estaba disponible. Ejecutando ensurepip..."
+        python -m ensurepip --upgrade
+    }
+
+    Write-Host "Actualizando pip..." -ForegroundColor Cyan
+    python -m pip install --upgrade pip
+
+    Write-Host "Instalando dependencias del proyecto..." -ForegroundColor Cyan
+    python -m pip install -r requirements.txt
+
+    if (-not $env:FLASK_APP) { $env:FLASK_APP = "wsgi.py" }
+    $env:FLASK_ENV = "development"
+
+    $databasePath = Join-Path $projectRoot "inventario.db"
+    $isNewDatabase = -not (Test-Path $databasePath)
+
+    Write-Host "Aplicando migraciones..." -ForegroundColor Cyan
+    flask db upgrade
+
+    if ($isNewDatabase) {
+        Write-Host "Base de datos nueva detectada. Ejecutando seed demo..." -ForegroundColor Cyan
+        flask seed demo
+    } else {
+        Write-Host "Base de datos existente detectada en $databasePath. Puede ejecutar 'flask seed demo' manualmente si necesita resembrar." -ForegroundColor DarkGray
+    }
+
+    Write-Host "Levantando servidor en http://127.0.0.1:5000 ..." -ForegroundColor Green
+    flask run --host=127.0.0.1 --port=5000
+}
+catch [System.Management.Automation.CommandNotFoundException] {
+    Write-Error $_.Exception.Message
+    Write-Host "Descarga Python desde https://www.python.org/downloads/ y repite la ejecución." -ForegroundColor Yellow
+    exit 1
+}
+catch {
+    Write-Error $_.Exception.Message
+    Write-Host "Para problemas de políticas ejecute: Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Yellow
+    Write-Host "Si falta SQLite instale el componente 'Optional Feature: SQLite' o revise la instalación de Python." -ForegroundColor Yellow
+    exit 1
+}


### PR DESCRIPTION
## Summary
- add a Flask CLI command group with `seed demo`, `promote-superadmin`, and `list-perms`
- extend the seed helpers to guarantee the Superadmin role, permissions, and admin user
- provide reusable picker macros in templates and update Windows docs plus new PowerShell scripts

## Testing
- pytest --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68dd5ab73da483248288c4a3b5e3197b