### PR TITLE
Improve PowerShell dev script error handling

### DIFF
--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -54,17 +54,26 @@ try {
     $isNewDatabase = -not (Test-Path $databasePath)
 
     Write-Host "Aplicando migraciones..." -ForegroundColor Cyan
-    flask db upgrade
+    flask dbsafe-upgrade
+    if ($LASTEXITCODE -ne 0) {
+        throw "La migración falló con código de salida $LASTEXITCODE."
+    }
 
     if ($isNewDatabase) {
         Write-Host "Base de datos nueva detectada. Ejecutando seed demo..." -ForegroundColor Cyan
         flask seed demo
+        if ($LASTEXITCODE -ne 0) {
+            throw "La carga de datos demo falló con código de salida $LASTEXITCODE."
+        }
     } else {
         Write-Host "Base de datos existente detectada en $databasePath. Puede ejecutar 'flask seed demo' manualmente si necesita resembrar." -ForegroundColor DarkGray
     }
 
     Write-Host "Levantando servidor en http://127.0.0.1:5000 ..." -ForegroundColor Green
     flask run --host=127.0.0.1 --port=5000
+    if ($LASTEXITCODE -ne 0) {
+        throw "El servidor Flask terminó con código de salida $LASTEXITCODE."
+    }
 }
 catch [System.Management.Automation.CommandNotFoundException] {
     Write-Error $_.Exception.Message


### PR DESCRIPTION
## Summary
- replace the migration step with the dbsafe-upgrade helper that merges heads automatically
- fail fast after migration, seed, or run commands if they exit with a non-zero status

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de60178d488324ab7441d80dec0a66