### PR TITLE
Adjust sidebar link color hex codes

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,7 +1,7 @@
 :root {
   --sidebar-width: 260px;
   --sidebar-bg: #0f1f33;
-  --sidebar-link-color: #fff;
+  --sidebar-link-color: #ffffff;
   --sidebar-section-title-color: rgba(255, 255, 255, 0.9);
   --sidebar-link-hover-bg: rgba(255, 255, 255, 0.12);
   --sidebar-link-active-bg: rgba(255, 255, 255, 0.08);
@@ -10,7 +10,7 @@
 
 [data-bs-theme='dark'] {
   --sidebar-bg: #0f1f33;
-  --sidebar-link-color: #fff;
+  --sidebar-link-color: #ffffff;
   --sidebar-link-hover-bg: rgba(255, 255, 255, 0.18);
   --sidebar-link-active-bg: rgba(255, 255, 255, 0.16);
   --sidebar-section-title-color: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
## Summary
- update the sidebar link color CSS variable to use the full white hex code in both light and dark themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee7bc833c8324b260a00b2b81a729