### PR TITLE
Track insumo serial assignments per equipo

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -281,9 +281,11 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         HospitalUsuarioRol,
         Insumo,
         InsumoMovimiento,
+        InsumoSerie,
         Licencia,
         Modulo,
         MovimientoTipo,
+        SerieEstado,
         Oficina,
         Permiso,
         Rol,
@@ -294,8 +296,8 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         TipoEquipo,
         TipoLicencia,
         Usuario,
+        EquipoInsumo,
         EstadoLicencia,
-        equipo_insumos,
     )
 
     _ = (
@@ -312,9 +314,11 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         HospitalUsuarioRol,
         Insumo,
         InsumoMovimiento,
+        InsumoSerie,
         Licencia,
         Modulo,
         MovimientoTipo,
+        SerieEstado,
         Oficina,
         Permiso,
         Rol,
@@ -325,8 +329,9 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         TipoEquipo,
         TipoLicencia,
         Usuario,
+        EquipoInsumo,
         EstadoLicencia,
-        equipo_insumos,
+        SerieEstado,
     )
 
     return app

--- a/app/forms/insumo.py
+++ b/app/forms/insumo.py
@@ -5,7 +5,7 @@ from flask_wtf import FlaskForm
 from wtforms import DecimalField, IntegerField, SelectField, StringField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired, Length, NumberRange, Optional, ValidationError
 
-from app.forms.fields import CSVIntegerListField, HiddenIntegerField
+from app.forms.fields import HiddenIntegerField
 from app.models import Equipo, MovimientoTipo
 
 
@@ -23,17 +23,7 @@ class InsumoForm(FlaskForm):
         validators=[Optional(), NumberRange(min=0)],
         places=2,
     )
-    equipos = CSVIntegerListField("Equipos asociados", validators=[Optional()])
     submit = SubmitField("Guardar")
-
-    def validate_equipos(self, field: CSVIntegerListField) -> None:  # type: ignore[override]
-        if not field.data:
-            return
-        existentes = Equipo.query.filter(Equipo.id.in_(field.data)).all()
-        encontrados = {equipo.id for equipo in existentes}
-        faltantes = [str(eid) for eid in field.data if eid not in encontrados]
-        if faltantes:
-            raise ValidationError("Algunos equipos seleccionados no existen")
 
 
 class MovimientoForm(FlaskForm):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,7 +10,7 @@ from .equipo import Equipo, EquipoHistorial, EstadoEquipo, TipoEquipo
 from .equipo_adjunto import EquipoAdjunto
 from .hospital import Hospital, Oficina, Servicio
 from .hospital_usuario_rol import HospitalUsuarioRol
-from .insumo import Insumo, InsumoMovimiento, MovimientoTipo, equipo_insumos
+from .insumo import EquipoInsumo, Insumo, InsumoMovimiento, InsumoSerie, MovimientoTipo, SerieEstado
 from .licencia import Licencia, TipoLicencia, EstadoLicencia
 from .permisos import Modulo, Permiso
 from .rol import Rol
@@ -37,8 +37,10 @@ __all__ = [
     "HospitalUsuarioRol",
     "Insumo",
     "InsumoMovimiento",
+    "InsumoSerie",
+    "EquipoInsumo",
     "MovimientoTipo",
-    "equipo_insumos",
+    "SerieEstado",
     "Licencia",
     "TipoLicencia",
     "EstadoLicencia",

--- a/app/services/dashboard_service.py
+++ b/app/services/dashboard_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import false
 
 from app.extensions import db
 from app.models import (
+    EquipoInsumo,
     EstadoEquipo,
     EstadoLicencia,
     Equipo,
@@ -16,7 +17,6 @@ from app.models import (
     Licencia,
     TipoEquipo,
     Usuario,
-    equipo_insumos,
 )
 from app.utils.scope import ScopeValue, get_user_hospital_scope
 
@@ -40,17 +40,22 @@ def _insumo_scope_filter(scope: ScopeValue):
         return false()
     associated = (
         select(1)
-        .select_from(equipo_insumos.join(Equipo, equipo_insumos.c.equipo_id == Equipo.id))
+        .select_from(EquipoInsumo)
+        .join(Equipo, EquipoInsumo.equipo_id == Equipo.id)
         .where(
-            equipo_insumos.c.insumo_id == Insumo.id,
+            EquipoInsumo.insumo_id == Insumo.id,
+            EquipoInsumo.fecha_desasociacion.is_(None),
             Equipo.hospital_id.in_(scope),
         )
         .exists()
     )
     any_association = (
         select(1)
-        .select_from(equipo_insumos)
-        .where(equipo_insumos.c.insumo_id == Insumo.id)
+        .select_from(EquipoInsumo)
+        .where(
+            EquipoInsumo.insumo_id == Insumo.id,
+            EquipoInsumo.fecha_desasociacion.is_(None),
+        )
         .exists()
     )
     return or_(associated, ~any_association)

--- a/app/static/js/pages/equipos_detalle.js
+++ b/app/static/js/pages/equipos_detalle.js
@@ -20,6 +20,136 @@
     return element;
   }
 
+  function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
+  }
+
+  function showToast(message, variant = 'success') {
+    const container = document.querySelector('[data-toast-container]');
+    if (!container || typeof bootstrap === 'undefined' || !message) {
+      return;
+    }
+    const toast = document.createElement('div');
+    toast.className = `toast align-items-center text-bg-${variant} border-0`;
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    toast.setAttribute('aria-atomic', 'true');
+    toast.innerHTML = `
+      <div class="d-flex">
+        <div class="toast-body">${message}</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+      </div>
+    `;
+    container.appendChild(toast);
+    const instance = bootstrap.Toast.getOrCreateInstance(toast, { delay: 4000 });
+    toast.addEventListener('hidden.bs.toast', () => {
+      toast.remove();
+    });
+    instance.show();
+  }
+
+  function formatDateTime(value) {
+    if (!value) {
+      return '—';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function ensureEmptyRow(table) {
+    if (!table) {
+      return;
+    }
+    const hasRows = table.querySelector('[data-insumo-row]');
+    let emptyRow = table.querySelector('[data-empty-row]');
+    if (hasRows) {
+      if (emptyRow) {
+        emptyRow.remove();
+      }
+      return;
+    }
+    const colSpan = parseInt(table.dataset.emptyColspan || '1', 10) || 1;
+    if (emptyRow) {
+      const cell = emptyRow.querySelector('td');
+      if (cell) {
+        cell.colSpan = colSpan;
+      }
+      emptyRow.classList.remove('d-none');
+      return;
+    }
+    const tbody = table.tBodies[0] || table.querySelector('tbody');
+    if (!tbody) {
+      return;
+    }
+    emptyRow = document.createElement('tr');
+    emptyRow.setAttribute('data-empty-row', '');
+    const cell = document.createElement('td');
+    cell.className = 'text-muted text-center py-3';
+    cell.colSpan = colSpan;
+    cell.textContent = 'Sin insumos vinculados.';
+    emptyRow.appendChild(cell);
+    tbody.appendChild(emptyRow);
+  }
+
+  function appendAssociationRow(table, data, canRemove) {
+    if (!table || !data || !data.serie) {
+      return;
+    }
+    const tbody = table.tBodies[0] || table.querySelector('tbody');
+    if (!tbody) {
+      return;
+    }
+    const row = document.createElement('tr');
+    row.setAttribute('data-insumo-row', '');
+    row.dataset.serieId = data.serie.id;
+
+    const insumoCell = document.createElement('td');
+    insumoCell.textContent = data.insumo && data.insumo.nombre ? data.insumo.nombre : 'Insumo';
+    row.appendChild(insumoCell);
+
+    const serieCell = document.createElement('td');
+    serieCell.className = 'font-monospace';
+    serieCell.textContent = data.serie.nro_serie || '';
+    row.appendChild(serieCell);
+
+    const fechaCell = document.createElement('td');
+    fechaCell.textContent = formatDateTime(data.fecha_asociacion);
+    row.appendChild(fechaCell);
+
+    const usuarioCell = document.createElement('td');
+    usuarioCell.textContent = data.asociado_por || '—';
+    row.appendChild(usuarioCell);
+
+    if (canRemove) {
+      const accionesCell = document.createElement('td');
+      accionesCell.className = 'text-end';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'btn btn-sm btn-outline-danger';
+      button.textContent = 'Quitar';
+      button.setAttribute('data-remove-insumo', '');
+      accionesCell.appendChild(button);
+      row.appendChild(accionesCell);
+    }
+
+    const emptyRow = table.querySelector('[data-empty-row]');
+    if (emptyRow) {
+      emptyRow.remove();
+    }
+    tbody.prepend(row);
+    ensureEmptyRow(table);
+  }
+
   class RemotePanel {
     constructor(root) {
       this.root = root;
@@ -272,5 +402,144 @@
     document.querySelectorAll("[data-remote-panel]").forEach((panel) => {
       new RemotePanel(panel);
     });
+
+    const table = document.querySelector('[data-insumos-table]');
+    if (table) {
+      ensureEmptyRow(table);
+      const canRemove = table.dataset.canRemove === '1';
+      const removeUrl = table.dataset.removeUrl;
+      if (canRemove && removeUrl) {
+        table.addEventListener('click', async (event) => {
+          const button = event.target.closest('[data-remove-insumo]');
+          if (!button) {
+            return;
+          }
+          const row = button.closest('[data-insumo-row]');
+          const serieId = row ? row.dataset.serieId : null;
+          if (!row || !serieId) {
+            return;
+          }
+          const originalHtml = button.innerHTML;
+          button.disabled = true;
+          button.innerHTML = 'Quitando…';
+          try {
+            const response = await fetch(removeUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken(),
+              },
+              credentials: 'include',
+              body: JSON.stringify({ insumo_serie_id: serieId }),
+            });
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+              throw new Error((data && data.message) || 'No se pudo remover el insumo');
+            }
+            row.remove();
+            ensureEmptyRow(table);
+            showToast((data && data.message) || 'Insumo removido', 'success');
+          } catch (error) {
+            showToast(error && error.message ? error.message : 'No se pudo remover el insumo', 'danger');
+          } finally {
+            button.disabled = false;
+            button.innerHTML = originalHtml;
+          }
+        });
+      }
+
+      const form = document.querySelector('[data-associate-form]');
+      if (form) {
+        const select = form.querySelector('select[name="nro_serie"]');
+        const submitButton = form.querySelector('[data-associate-submit]');
+        const errorBox = form.querySelector('[data-associate-error]');
+        const modalElement = form.closest('.modal');
+        const modalInstance =
+          modalElement && typeof bootstrap !== 'undefined'
+            ? bootstrap.Modal.getOrCreateInstance(modalElement)
+            : null;
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          if (!select) {
+            return;
+          }
+          const rawValue = select.tomselect ? select.tomselect.getValue() : select.value;
+          const nroSerie = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+          if (!nroSerie) {
+            if (errorBox) {
+              errorBox.textContent = 'Seleccione un número de serie disponible.';
+              errorBox.classList.remove('d-none');
+            }
+            return;
+          }
+          if (errorBox) {
+            errorBox.classList.add('d-none');
+            errorBox.textContent = '';
+          }
+          const url = form.dataset.associateUrl;
+          if (!url) {
+            return;
+          }
+          const originalLabel = submitButton ? submitButton.textContent : '';
+          if (submitButton) {
+            submitButton.disabled = true;
+            submitButton.textContent = 'Asociando…';
+          }
+          try {
+            const response = await fetch(url, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken(),
+              },
+              credentials: 'include',
+              body: JSON.stringify({ nro_serie: nroSerie }),
+            });
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+              throw new Error((data && data.message) || 'No se pudo asociar el insumo');
+            }
+            appendAssociationRow(table, data.asociacion || {}, table.dataset.canRemove === '1');
+            showToast((data && data.message) || 'Insumo asociado', 'success');
+            if (select.tomselect) {
+              select.tomselect.clear();
+              select.tomselect.focus();
+            } else {
+              select.value = '';
+            }
+            if (modalInstance) {
+              modalInstance.hide();
+            }
+          } catch (error) {
+            if (errorBox) {
+              errorBox.textContent = error && error.message ? error.message : 'No se pudo asociar el insumo';
+              errorBox.classList.remove('d-none');
+            } else {
+              showToast(error && error.message ? error.message : 'No se pudo asociar el insumo', 'danger');
+            }
+          } finally {
+            if (submitButton) {
+              submitButton.disabled = false;
+              submitButton.textContent = originalLabel || 'Asociar';
+            }
+          }
+        });
+
+        if (modalElement && modalInstance) {
+          modalElement.addEventListener('hidden.bs.modal', () => {
+            if (errorBox) {
+              errorBox.classList.add('d-none');
+              errorBox.textContent = '';
+            }
+            if (select && select.tomselect) {
+              select.tomselect.clear();
+            } else if (select) {
+              select.value = '';
+            }
+          });
+        }
+      }
+    }
   });
 })();

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -104,17 +104,48 @@
 <div class="row g-3">
   <div class="col-md-6">
     <div class="card h-100">
-      <div class="card-header">Insumos asociados</div>
-      <ul class="list-group list-group-flush">
-        {% for insumo in insumos %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ insumo.nombre }}</span>
-          <span class="badge bg-secondary">Stock: {{ insumo.stock }}</span>
-        </li>
-        {% else %}
-        <li class="list-group-item text-muted">Sin insumos vinculados.</li>
-        {% endfor %}
-      </ul>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Insumos asociados</span>
+        {% if current_user.has_permission('inventario:write') %}
+        <button class="btn btn-sm btn-primary" type="button" data-bs-toggle="modal" data-bs-target="#asociarInsumoModal">Asociar insumo</button>
+        {% endif %}
+      </div>
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-sm mb-0 align-middle" data-insumos-table data-remove-url="{{ url_for('equipos.quitar_insumo', equipo_id=equipo.id) }}" data-can-remove="{{ '1' if current_user.has_permission('inventario:write') else '0' }}" data-empty-colspan="{% if current_user.has_permission('inventario:write') %}5{% else %}4{% endif %}">
+            <thead class="table-light">
+              <tr>
+                <th scope="col">Insumo</th>
+                <th scope="col">Nº de serie</th>
+                <th scope="col">Fecha</th>
+                <th scope="col">Asignado por</th>
+                {% if current_user.has_permission('inventario:write') %}
+                <th scope="col" class="text-end">Acciones</th>
+                {% endif %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for asignacion in insumos %}
+              <tr data-insumo-row data-serie-id="{{ asignacion.serie.id }}">
+                <td>{{ asignacion.insumo.nombre }}</td>
+                <td class="font-monospace">{{ asignacion.serie.nro_serie }}</td>
+                <td>{{ asignacion.fecha_asociacion.strftime('%d/%m/%Y %H:%M') if asignacion.fecha_asociacion else '—' }}</td>
+                <td>{{ asignacion.asociado_por.nombre if asignacion.asociado_por else '—' }}</td>
+                {% if current_user.has_permission('inventario:write') %}
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-danger" type="button" data-remove-insumo>Quitar</button>
+                </td>
+                {% endif %}
+              </tr>
+              {% else %}
+              <tr data-empty-row>
+                <td colspan="{% if current_user.has_permission('inventario:write') %}5{% else %}4{% endif %}" class="text-muted text-center py-3">Sin insumos vinculados.</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
   <div class="col-md-6">
@@ -297,6 +328,31 @@
     </div>
   </div>
 </div>
+{% if current_user.has_permission('inventario:write') %}
+<div class="modal fade" id="asociarInsumoModal" tabindex="-1" aria-labelledby="asociarInsumoLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" data-associate-form data-associate-url="{{ url_for('equipos.asociar_insumo', equipo_id=equipo.id) }}">
+      <div class="modal-header">
+        <h5 class="modal-title" id="asociarInsumoLabel">Asociar insumo por Nº de serie</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label" for="nroSerieSelect">Número de serie</label>
+          <select class="form-select" id="nroSerieSelect" name="nro_serie" data-control="tom-select" data-endpoint="{{ url_for('insumos.series_disponibles') }}" data-placeholder="Buscar serie disponible…" data-min-chars="2" required></select>
+          <div class="form-text">Se muestran únicamente series disponibles para asociar.</div>
+        </div>
+        <div class="alert alert-danger d-none" role="alert" data-associate-error></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button class="btn btn-primary" type="submit" data-associate-submit>Asociar</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endif %}
+<div class="toast-container position-fixed bottom-0 end-0 p-3" data-toast-container aria-live="polite" aria-atomic="true"></div>
 {% endblock %}
 
 {% block scripts %}

--- a/app/templates/insumos/formulario.html
+++ b/app/templates/insumos/formulario.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_form_helpers.html' import render_field, render_textarea, render_equipo_selector %}
+{% from '_form_helpers.html' import render_field, render_textarea %}
 {% block title %}{{ titulo }}{% endblock %}
 {% block content %}
 <h1 class="h3 mb-4">{{ titulo }}</h1>
@@ -13,15 +13,6 @@
     {{ render_field(form.stock_minimo, form_group_class='col-md-3', input_class='form-control', min_value='0') }}
     {{ render_field(form.costo_unitario, form_group_class='col-md-3', input_class='form-control', step='0.01') }}
     {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3) }}
-    {{ render_equipo_selector(
-      form.equipos,
-      form_group_class='col-12',
-      label='Equipos asociados',
-      placeholder='Busque equipos por tipo, marca o serie…',
-      multiple=True,
-      allow_clear=True,
-      initial_options=equipos_options or []
-    ) }}
   </div>
   <div class="mt-4 d-flex gap-2">
     {{ form.submit(class='btn btn-primary') }}

--- a/migrations/versions/0003_insumo_series_equipo_insumos.py
+++ b/migrations/versions/0003_insumo_series_equipo_insumos.py
@@ -1,0 +1,85 @@
+"""Add serialised insumo tracking and equipo association history."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0003_insumo_series_equipo_insumos"
+down_revision = "0002_equipo_search_tipo_desc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tables to gestionar series de insumos y asociaciones."""
+
+    op.drop_table("equipo_insumos")
+
+    estado_enum = sa.Enum("libre", "asignado", "dado_baja", name="insumo_serie_estado")
+    estado_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "insumo_series",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("insumo_id", sa.Integer(), sa.ForeignKey("insumos.id"), nullable=False),
+        sa.Column("nro_serie", sa.String(length=128), nullable=False),
+        sa.Column(
+            "estado",
+            estado_enum,
+            nullable=False,
+            server_default="libre",
+        ),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), nullable=True),
+    )
+    op.create_index("ix_insumo_series_insumo_id", "insumo_series", ["insumo_id"])
+    op.create_index("ix_insumo_series_nro_serie", "insumo_series", ["nro_serie"], unique=True)
+    op.create_index("ix_insumo_series_equipo_id", "insumo_series", ["equipo_id"])
+
+    op.create_table(
+        "equipos_insumos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), nullable=False),
+        sa.Column("insumo_id", sa.Integer(), sa.ForeignKey("insumos.id"), nullable=False),
+        sa.Column(
+            "insumo_serie_id",
+            sa.Integer(),
+            sa.ForeignKey("insumo_series.id"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("asociado_por_id", sa.Integer(), sa.ForeignKey("usuarios.id")),
+        sa.Column(
+            "fecha_asociacion",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("fecha_desasociacion", sa.DateTime(timezone=True)),
+        sa.UniqueConstraint("equipo_id", "insumo_serie_id", name="uq_equipo_serie_unica"),
+    )
+    op.create_index("ix_equipos_insumos_equipo_id", "equipos_insumos", ["equipo_id"])
+    op.create_index("ix_equipos_insumos_insumo_id", "equipos_insumos", ["insumo_id"])
+
+
+def downgrade() -> None:
+    """Revert the creation of insumo series and association tables."""
+
+    op.drop_index("ix_equipos_insumos_insumo_id", table_name="equipos_insumos")
+    op.drop_index("ix_equipos_insumos_equipo_id", table_name="equipos_insumos")
+    op.drop_table("equipos_insumos")
+
+    op.drop_index("ix_insumo_series_equipo_id", table_name="insumo_series")
+    op.drop_index("ix_insumo_series_nro_serie", table_name="insumo_series")
+    op.drop_index("ix_insumo_series_insumo_id", table_name="insumo_series")
+    op.drop_table("insumo_series")
+
+    estado_enum = sa.Enum("libre", "asignado", "dado_baja", name="insumo_serie_estado")
+    estado_enum.drop(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "equipo_insumos",
+        sa.Column("equipo_id", sa.Integer(), sa.ForeignKey("equipos.id"), primary_key=True),
+        sa.Column("insumo_id", sa.Integer(), sa.ForeignKey("insumos.id"), primary_key=True),
+    )


### PR DESCRIPTION
## Summary
- add InsumoSerie and EquipoInsumo models plus migration to handle serialised consumables and their history
- expose endpoints and UI flow to associate or detach insumos by serial number from the equipo detail view
- align forms, dashboard queries, and autocomplete endpoints with the new stock handling behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df000c1eb88324adeade5db404441c