### PR TITLE
Implementar thumbnails de evidencias, formato fecha y paginación

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,7 @@ from app.extensions import configure_logging, db, init_extensions, login_manager
 from app.security.rbac import has_role
 from app.utils import (
     build_select_attrs,
+    format_spanish_date,
     humanize_bytes,
     normalize_enum_value,
     render_input_field,
@@ -187,6 +188,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     app.jinja_env.filters.setdefault("enum_value", normalize_enum_value)
     app.jinja_env.filters.setdefault("humanize_bytes", humanize_bytes)
     app.jinja_env.filters.setdefault("combine", _combine_dicts)
+    app.jinja_env.filters.setdefault("fecha", format_spanish_date)
 
     from app.models.usuario import Usuario  # imported lazily to avoid circular imports
 
@@ -213,6 +215,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
     from app.routes.docscan import docscan_bp
     from app.routes.equipos import equipos_bp
     from app.routes.insumos import insumos_bp
+    from app.routes.files import files_bp
     from app.routes.licencias.routes import licencias_bp
     from app.routes.main import main_bp
     from app.routes.permisos import permisos_bp
@@ -230,6 +233,7 @@ def create_app(config_class: type[Config] | Config = Config) -> Flask:
         ubicaciones_bp,
         adjuntos_bp,
         docscan_bp,
+        files_bp,
         permisos_bp,
         auditoria_bp,
         actas_bp,

--- a/app/forms/docscan.py
+++ b/app/forms/docscan.py
@@ -21,7 +21,13 @@ class DocscanForm(FlaskForm):
     hospital_id = SelectField("Hospital", coerce=int, validators=[Optional()])
     servicio_id = SelectField("Servicio", coerce=int, validators=[Optional()])
     oficina_id = SelectField("Oficina", coerce=int, validators=[Optional()])
-    fecha_documento = DateField("Fecha del documento", validators=[Optional()])
+    _date_render = {"placeholder": "dd/mm/aaaa", "data-date-format": "d/m/Y", "autocomplete": "off"}
+    fecha_documento = DateField(
+        "Fecha del documento",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
     comentario = TextAreaField("Comentario", validators=[Optional(), Length(max=500)])
     archivo = FileField(
         "Archivo",

--- a/app/forms/equipo.py
+++ b/app/forms/equipo.py
@@ -26,8 +26,6 @@ from app.models import (
     TipoActa,
     TipoEquipo,
 )
-
-
 class EquipoForm(FlaskForm):
     """Create or edit an equipment entry."""
 
@@ -44,9 +42,28 @@ class EquipoForm(FlaskForm):
     servicio_id = IntegerField("Servicio", validators=[Optional()])
     oficina_id = IntegerField("Oficina", validators=[Optional()])
     responsable = StringField("Responsable", validators=[Optional(), Length(max=120)])
-    fecha_ingreso = DateField("Fecha de ingreso", validators=[Optional()], default=None)
-    fecha_instalacion = DateField("Fecha de instalación", validators=[Optional()], default=None)
-    garantia_hasta = DateField("Garantía hasta", validators=[Optional()], default=None)
+    _date_render = {"placeholder": "dd/mm/aaaa", "data-date-format": "d/m/Y", "autocomplete": "off"}
+    fecha_ingreso = DateField(
+        "Fecha de ingreso",
+        validators=[Optional()],
+        default=None,
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
+    fecha_instalacion = DateField(
+        "Fecha de instalación",
+        validators=[Optional()],
+        default=None,
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
+    garantia_hasta = DateField(
+        "Garantía hasta",
+        validators=[Optional()],
+        default=None,
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
     observaciones = TextAreaField("Observaciones", validators=[Optional(), Length(max=1000)])
     sin_numero_serie = BooleanField("Sin número de serie visible", default=False)
     es_nuevo = BooleanField("Equipo nuevo", default=False)
@@ -179,6 +196,7 @@ class EquipoAdjuntoForm(FlaskForm):
 class EquipoAdjuntoDeleteForm(FlaskForm):
     """Simple CSRF protected form to remove an attachment."""
 
+    next = HiddenField()
     submit = SubmitField("Eliminar")
 
 
@@ -186,8 +204,18 @@ class EquipoHistorialFiltroForm(FlaskForm):
     """Filter historical entries for an equipment."""
 
     accion = StringField("Acción", validators=[Optional(), Length(max=120)])
-    fecha_desde = DateField("Desde", validators=[Optional()])
-    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    fecha_desde = DateField(
+        "Desde",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=EquipoForm._date_render,
+    )
+    fecha_hasta = DateField(
+        "Hasta",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=EquipoForm._date_render,
+    )
     submit = SubmitField("Filtrar")
 
     def validate(self, extra_validators=None):  # type: ignore[override]
@@ -207,8 +235,18 @@ class EquipoActaFiltroForm(FlaskForm):
     """Filter actas associated with an equipment."""
 
     tipo = SelectField("Tipo", coerce=str, validators=[Optional()])
-    fecha_desde = DateField("Desde", validators=[Optional()])
-    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    fecha_desde = DateField(
+        "Desde",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=EquipoForm._date_render,
+    )
+    fecha_hasta = DateField(
+        "Hasta",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=EquipoForm._date_render,
+    )
     submit = SubmitField("Filtrar")
 
     def __init__(self, *args, **kwargs) -> None:

--- a/app/forms/licencia.py
+++ b/app/forms/licencia.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from datetime import date
 
+from datetime import date
+
 from flask_wtf import FlaskForm
 from wtforms import DateField, SelectField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired, Length, Optional, ValidationError
@@ -13,13 +15,24 @@ from app.models import TipoLicencia
 class LicenciaForm(FlaskForm):
     """Form to request a new license."""
 
+    _date_render = {"placeholder": "dd/mm/aaaa", "data-date-format": "d/m/Y", "autocomplete": "off"}
     tipo = SelectField(
         "Tipo de licencia",
         choices=[(t.value, t.name.title()) for t in TipoLicencia],
         validators=[DataRequired()],
     )
-    fecha_inicio = DateField("Fecha de inicio", validators=[DataRequired()])
-    fecha_fin = DateField("Fecha de fin", validators=[DataRequired()])
+    fecha_inicio = DateField(
+        "Fecha de inicio",
+        validators=[DataRequired()],
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
+    fecha_fin = DateField(
+        "Fecha de fin",
+        validators=[DataRequired()],
+        format="%d/%m/%Y",
+        render_kw=_date_render,
+    )
     hospital_id = SelectField(
         "Hospital",
         coerce=int,
@@ -48,7 +61,13 @@ class AprobarRechazarForm(FlaskForm):
 class CalendarioFiltroForm(FlaskForm):
     """Filter for license calendar."""
 
-    mes = DateField("Mes", default=date.today, validators=[Optional()])
+    mes = DateField(
+        "Mes",
+        default=date.today,
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=LicenciaForm._date_render,
+    )
     submit = SubmitField("Filtrar")
 
 
@@ -67,8 +86,18 @@ class MisLicenciasFiltroForm(FlaskForm):
         validators=[Optional()],
         description="Filtrar por tipo de licencia.",
     )
-    fecha_desde = DateField("Desde", validators=[Optional()])
-    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    fecha_desde = DateField(
+        "Desde",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=LicenciaForm._date_render,
+    )
+    fecha_hasta = DateField(
+        "Hasta",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=LicenciaForm._date_render,
+    )
     submit = SubmitField("Aplicar filtros")
 
 
@@ -88,8 +117,18 @@ class GestionLicenciasFiltroForm(FlaskForm):
         validators=[Optional()],
     )
     estado = SelectField("Estado", choices=[], validators=[Optional()])
-    fecha_desde = DateField("Desde", validators=[Optional()])
-    fecha_hasta = DateField("Hasta", validators=[Optional()])
+    fecha_desde = DateField(
+        "Desde",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=LicenciaForm._date_render,
+    )
+    fecha_hasta = DateField(
+        "Hasta",
+        validators=[Optional()],
+        format="%d/%m/%Y",
+        render_kw=LicenciaForm._date_render,
+    )
     submit = SubmitField("Aplicar filtros")
 
 

--- a/app/models/equipo.py
+++ b/app/models/equipo.py
@@ -80,6 +80,7 @@ class EstadoEquipo(str, Enum):
 
     OPERATIVO = "operativo"
     SERVICIO_TECNICO = "servicio_tecnico"
+    EN_TALLER = "en_taller"
     DE_BAJA = "de_baja"
     PRESTADO = "prestado"
 

--- a/app/routes/files/__init__.py
+++ b/app/routes/files/__init__.py
@@ -1,0 +1,4 @@
+"""Blueprint exposing file serving helpers for equipment evidences."""
+from .routes import files_bp
+
+__all__ = ["files_bp"]

--- a/app/routes/files/routes.py
+++ b/app/routes/files/routes.py
@@ -1,0 +1,157 @@
+"""Serve and manage evidence files."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    g,
+    redirect,
+    request,
+    send_file,
+    url_for,
+)
+from flask_login import current_user, login_required
+from sqlalchemy.orm import selectinload
+
+from app.extensions import db
+from app.forms.equipo import EquipoAdjuntoDeleteForm
+from app.models import EquipoAdjunto, Modulo
+from app.security import permissions_required, require_hospital_access
+from app.services.audit_service import log_action
+from app.services.file_service import (
+    generate_image_thumbnail,
+    purge_file_variants,
+    resolve_storage_path,
+    thumbnail_path,
+)
+
+
+files_bp = Blueprint("files", __name__, url_prefix="/files")
+
+
+def _ensure_allowed(adjunto: EquipoAdjunto) -> None:
+    equipo = adjunto.equipo
+    allowed = getattr(g, "allowed_hospitals", set())
+    if allowed and equipo and equipo.hospital_id not in allowed:
+        abort(404)
+
+
+def _load_adjunto(file_id: int) -> EquipoAdjunto:
+    adjunto = (
+        EquipoAdjunto.query.options(selectinload(EquipoAdjunto.equipo))
+        .filter_by(id=file_id)
+        .first()
+    )
+    if not adjunto:
+        abort(404)
+    _ensure_allowed(adjunto)
+    return adjunto
+
+
+def _resolve_or_404(adjunto: EquipoAdjunto) -> Path:
+    try:
+        stored_path = resolve_storage_path(adjunto.filepath)
+    except FileNotFoundError:  # pragma: no cover - defensive
+        abort(404)
+    if not stored_path.exists():
+        abort(404)
+    return stored_path
+
+
+def _fallback_target(adjunto: EquipoAdjunto) -> str:
+    target = request.args.get("next") or request.referrer
+    if not target and adjunto.equipo:
+        target = url_for("equipos.detalle", equipo_id=adjunto.equipo_id)
+    return target or url_for("equipos.listar")
+
+
+@files_bp.route("/view/<int:file_id>")
+@login_required
+@permissions_required("inventario:read")
+@require_hospital_access(Modulo.INVENTARIO)
+def view_file(file_id: int):
+    adjunto = _load_adjunto(file_id)
+    stored_path = _resolve_or_404(adjunto)
+    return send_file(stored_path, as_attachment=False, download_name=adjunto.filename)
+
+
+@files_bp.route("/download/<int:file_id>")
+@login_required
+@permissions_required("inventario:read")
+@require_hospital_access(Modulo.INVENTARIO)
+def download_file(file_id: int):
+    adjunto = _load_adjunto(file_id)
+    stored_path = _resolve_or_404(adjunto)
+    return send_file(stored_path, as_attachment=True, download_name=adjunto.filename)
+
+
+@files_bp.route("/thumb/<int:file_id>")
+@login_required
+@permissions_required("inventario:read")
+@require_hospital_access(Modulo.INVENTARIO)
+def thumbnail(file_id: int):
+    adjunto = _load_adjunto(file_id)
+    if not (adjunto.mime_type or "").startswith("image/"):
+        abort(404)
+    original = _resolve_or_404(adjunto)
+    thumb_path = thumbnail_path(original)
+    if not thumb_path.exists():
+        generated = generate_image_thumbnail(original)
+        if generated:
+            thumb_path = generated
+    if not thumb_path.exists():
+        return send_file(original, as_attachment=False, download_name=adjunto.filename)
+    return send_file(thumb_path, as_attachment=False, download_name=thumb_path.name)
+
+
+@files_bp.route("/delete/<int:file_id>", methods=["POST"])
+@login_required
+@permissions_required("inventario:write")
+@require_hospital_access(Modulo.INVENTARIO)
+def delete_file(file_id: int):
+    form = EquipoAdjuntoDeleteForm()
+    if not form.validate_on_submit():
+        flash("No se pudo validar la solicitud.", "danger")
+        adjunto = _load_adjunto(file_id)
+        return redirect(_fallback_target(adjunto))
+
+    adjunto = _load_adjunto(file_id)
+    equipo = adjunto.equipo
+
+    try:
+        stored_path = _resolve_or_404(adjunto)
+    except Exception:  # pragma: no cover - handled by removing file
+        stored_path = None
+
+    thumb = thumbnail_path(stored_path) if stored_path else None
+    purge_file_variants(path for path in [stored_path, thumb] if path)
+    if stored_path:
+        parent = stored_path.parent
+        if parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+
+    redirect_target = _fallback_target(adjunto)
+
+    db.session.delete(adjunto)
+    if equipo:
+        equipo.registrar_evento(
+            current_user,
+            "Adjunto",
+            f"Archivo {adjunto.filename} eliminado",
+        )
+    db.session.commit()
+    log_action(
+        usuario_id=current_user.id,
+        accion="eliminar_adjunto",
+        modulo="inventario",
+        tabla="equipos_adjuntos",
+        registro_id=adjunto.id,
+    )
+    flash("Adjunto eliminado correctamente.", "success")
+    return redirect(redirect_target)
+
+
+__all__ = ["files_bp"]

--- a/app/services/file_service.py
+++ b/app/services/file_service.py
@@ -1,0 +1,91 @@
+"""Helpers to manage evidence files stored on disk."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from flask import current_app
+
+try:  # pragma: no cover - dependency optional in some environments
+    from PIL import Image  # type: ignore
+except ImportError:  # pragma: no cover - gracefully fallback when Pillow missing
+    Image = None  # type: ignore
+
+
+THUMBNAIL_SIZE = (300, 300)
+THUMBNAIL_SUFFIX = "_thumb.webp"
+
+
+def equipment_upload_dir(equipo_id: int) -> Path:
+    """Return the upload directory for a given equipment id."""
+
+    base = Path(current_app.config["EQUIPOS_UPLOAD_FOLDER"])
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / str(equipo_id)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def resolve_storage_path(filepath: str) -> Path:
+    """Resolve ``filepath`` ensuring it stays inside the configured directory."""
+
+    configured = Path(current_app.config["EQUIPOS_UPLOAD_FOLDER"]).resolve()
+    stored = Path(filepath)
+    if not stored.is_absolute():
+        stored = configured / stored
+    stored = stored.resolve()
+    if configured not in stored.parents and stored != configured:
+        raise FileNotFoundError("Ubicación fuera del directorio permitido")
+    return stored
+
+
+def thumbnail_path(original: Path) -> Path:
+    """Return the expected thumbnail path for ``original``."""
+
+    return original.with_name(original.stem + THUMBNAIL_SUFFIX)
+
+
+def generate_image_thumbnail(original: Path) -> Path | None:
+    """Generate a WEBP thumbnail for ``original`` if it is an image."""
+
+    if not original.exists():
+        return None
+
+    thumb = thumbnail_path(original)
+    try:
+        if Image is None:
+            thumb.parent.mkdir(parents=True, exist_ok=True)
+            thumb.write_bytes(original.read_bytes())
+            current_app.logger.warning(
+                "Pillow no está instalado; se generó una miniatura de respaldo para %s.",
+                original,
+            )
+        else:
+            with Image.open(original) as image:  # pragma: no cover - exercised in prod envs
+                image = image.convert("RGB")
+                image.thumbnail(THUMBNAIL_SIZE)
+                thumb.parent.mkdir(parents=True, exist_ok=True)
+                image.save(thumb, "WEBP", quality=85, method=6)
+    except (OSError, ValueError) as exc:
+        current_app.logger.warning("No se pudo generar miniatura para %s: %s", original, exc)
+        return None
+    return thumb
+
+
+def purge_file_variants(paths: Iterable[Path]) -> None:
+    """Remove all ``paths`` from disk ignoring missing files."""
+
+    for candidate in paths:
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError:
+            current_app.logger.debug("No se pudo eliminar %s", candidate)
+
+
+__all__ = [
+    "equipment_upload_dir",
+    "resolve_storage_path",
+    "thumbnail_path",
+    "generate_image_thumbnail",
+    "purge_file_variants",
+]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -483,6 +483,12 @@ body {
   border: 1px solid rgba(191, 119, 6, 0.36);
 }
 
+.status-badge--info {
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+  border: 1px solid rgba(37, 99, 235, 0.3);
+}
+
 .status-badge--danger {
   background: rgba(185, 28, 28, 0.16);
   color: #7f1d1d;
@@ -503,4 +509,77 @@ body {
 
 .object-fit-cover {
   object-fit: cover;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
+}
+
+.evidencias-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 576px) {
+  .evidencias-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 992px) {
+  .evidencias-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.evidencia-card {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: var(--bs-card-box-shadow, 0 0.5rem 1rem rgba(15, 23, 42, 0.08));
+}
+
+.evidencia-thumb-wrapper {
+  position: relative;
+  padding-top: 66.66%;
+  background: #f8fafc;
+}
+
+.evidencia-thumb {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.evidencia-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #475569;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0.35));
+}
+
+.evidencia-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+}
+
+.evidencia-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/app/templates/_pagination.html
+++ b/app/templates/_pagination.html
@@ -1,34 +1,67 @@
-{% macro render_pagination(pagination, endpoint=None) -%}
-  {% if pagination.pages > 1 %}
+{% macro render_pagination(pagination, endpoint=None, param_name='page', params=None) -%}
+  {% if pagination and pagination.pages > 1 %}
     {% set endpoint = endpoint or request.endpoint %}
-    {% set params = request.args.to_dict() %}
+    {% set base_params = params.copy() if params else request.args.to_dict() %}
+    {% set view_args = request.view_args or {} %}
+    {% for key, value in view_args.items() %}
+      {% if key not in base_params %}
+        {% set _ = base_params.update({key: value}) %}
+      {% endif %}
+    {% endfor %}
+    {% set _ = base_params.pop(param_name, None) %}
     <nav aria-label="Paginación">
-      <ul class="pagination justify-content-end">
-        {% if pagination.has_prev %}
-          {% set prev_params = params.copy() %}
-          {% set _ = prev_params.update({'page': pagination.prev_num}) %}
-          <li class="page-item">
-            <a class="page-link" href="{{ url_for(endpoint, **prev_params) }}" aria-label="Anterior">Anterior</a>
-          </li>
-        {% else %}
-          <li class="page-item disabled">
-            <span class="page-link">Anterior</span>
-          </li>
-        {% endif %}
-        <li class="page-item disabled">
-          <span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span>
+      <ul class="pagination justify-content-end mb-0">
+        {% set first_params = base_params.copy() %}
+        {% set _ = first_params.update({param_name: 1}) %}
+        <li class="page-item{% if pagination.page == 1 %} disabled{% endif %}">
+          {% if pagination.page == 1 %}
+          <span class="page-link" aria-hidden="true">&laquo;</span>
+          {% else %}
+          <a class="page-link" href="{{ url_for(endpoint, **first_params) }}" aria-label="Primera">&laquo;</a>
+          {% endif %}
         </li>
-        {% if pagination.has_next %}
-          {% set next_params = params.copy() %}
-          {% set _ = next_params.update({'page': pagination.next_num}) %}
-          <li class="page-item">
-            <a class="page-link" href="{{ url_for(endpoint, **next_params) }}" aria-label="Siguiente">Siguiente</a>
-          </li>
-        {% else %}
-          <li class="page-item disabled">
-            <span class="page-link">Siguiente</span>
-          </li>
-        {% endif %}
+        {% set prev_params = base_params.copy() %}
+        {% set _ = prev_params.update({param_name: pagination.prev_num}) %}
+        <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+          {% if pagination.has_prev %}
+          <a class="page-link" href="{{ url_for(endpoint, **prev_params) }}" aria-label="Anterior">&lsaquo;</a>
+          {% else %}
+          <span class="page-link" aria-hidden="true">&lsaquo;</span>
+          {% endif %}
+        </li>
+        {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+          {% if page_num %}
+            {% set page_params = base_params.copy() %}
+            {% set _ = page_params.update({param_name: page_num}) %}
+            <li class="page-item{% if page_num == pagination.page %} active{% endif %}">
+              {% if page_num == pagination.page %}
+              <span class="page-link">{{ page_num }}</span>
+              {% else %}
+              <a class="page-link" href="{{ url_for(endpoint, **page_params) }}">{{ page_num }}</a>
+              {% endif %}
+            </li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">…</span></li>
+          {% endif %}
+        {% endfor %}
+        {% set next_params = base_params.copy() %}
+        {% set _ = next_params.update({param_name: pagination.next_num}) %}
+        <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+          {% if pagination.has_next %}
+          <a class="page-link" href="{{ url_for(endpoint, **next_params) }}" aria-label="Siguiente">&rsaquo;</a>
+          {% else %}
+          <span class="page-link" aria-hidden="true">&rsaquo;</span>
+          {% endif %}
+        </li>
+        {% set last_params = base_params.copy() %}
+        {% set _ = last_params.update({param_name: pagination.pages}) %}
+        <li class="page-item{% if pagination.page == pagination.pages %} disabled{% endif %}">
+          {% if pagination.page == pagination.pages %}
+          <span class="page-link" aria-hidden="true">&raquo;</span>
+          {% else %}
+          <a class="page-link" href="{{ url_for(endpoint, **last_params) }}" aria-label="Última">&raquo;</a>
+          {% endif %}
+        </li>
       </ul>
     </nav>
   {% endif %}

--- a/app/templates/actas/descargar.html
+++ b/app/templates/actas/descargar.html
@@ -5,7 +5,7 @@
 <div class="card mb-3">
   <div class="card-body">
     <p><strong>Tipo:</strong> {{ normalize_enum_value(acta.tipo)|title }}</p>
-    <p><strong>Fecha:</strong> {{ acta.fecha.strftime('%d/%m/%Y') }}</p>
+    <p><strong>Fecha:</strong> {{ acta.fecha|fecha }}</p>
     <p><strong>Hospital:</strong> {{ acta.hospital.nombre if acta.hospital else '—' }}</p>
     <p><strong>Observaciones:</strong> {{ acta.observaciones or '—' }}</p>
     <p><strong>Equipos:</strong></p>

--- a/app/templates/actas/listar.html
+++ b/app/templates/actas/listar.html
@@ -27,7 +27,7 @@
       <tr>
         <td>{{ acta.numero or acta.id }}</td>
         <td class="text-capitalize">{{ normalize_enum_value(acta.tipo) }}</td>
-        <td>{{ acta.fecha.strftime('%d/%m/%Y') }}</td>
+        <td>{{ acta.fecha|fecha }}</td>
         <td>{{ acta.hospital.nombre if acta.hospital else '—' }}</td>
         <td>{{ acta.items|length }}</td>
         <td class="text-end">

--- a/app/templates/actas/pdf.html
+++ b/app/templates/actas/pdf.html
@@ -13,7 +13,7 @@
 <body>
   <h1>Acta {{ acta.numero or acta.id }}</h1>
   <p><strong>Tipo:</strong> {{ normalize_enum_value(acta.tipo)|title }}</p>
-  <p><strong>Fecha:</strong> {{ acta.fecha.strftime('%d/%m/%Y') }}</p>
+  <p><strong>Fecha:</strong> {{ acta.fecha|fecha }}</p>
   <p><strong>Hospital:</strong> {{ acta.hospital.nombre if acta.hospital else '—' }}</p>
   <p><strong>Observaciones:</strong> {{ acta.observaciones or '—' }}</p>
   <table>

--- a/app/templates/adjuntos/detalle.html
+++ b/app/templates/adjuntos/detalle.html
@@ -7,7 +7,7 @@
     <p><strong>Equipo:</strong> {{ adjunto.equipo.descripcion or adjunto.equipo.codigo }}</p>
     <p><strong>Tipo:</strong> {{ normalize_enum_value(adjunto.tipo) }}</p>
     <p><strong>Subido por:</strong> {{ adjunto.uploaded_by.nombre if adjunto.uploaded_by else '—' }}</p>
-    <p><strong>Fecha:</strong> {{ adjunto.uploaded_at.strftime('%d/%m/%Y') }}</p>
+    <p><strong>Fecha:</strong> {{ adjunto.uploaded_at|fecha(False) }}</p>
     <p><strong>Descripción:</strong> {{ adjunto.descripcion or '—' }}</p>
     <a class="btn btn-primary" href="{{ url_for('adjuntos.descargar', adjunto_id=adjunto.id) }}">Descargar</a>
     <a class="btn btn-outline-secondary" href="{{ url_for('adjuntos.listar') }}">Volver</a>

--- a/app/templates/adjuntos/listar.html
+++ b/app/templates/adjuntos/listar.html
@@ -27,7 +27,7 @@
         <td>{{ adjunto.equipo.descripcion or adjunto.equipo.codigo }}</td>
         <td>{{ adjunto.filename }}</td>
         <td class="text-capitalize">{{ normalize_enum_value(adjunto.tipo).replace('_',' ') }}</td>
-        <td>{{ adjunto.uploaded_at.strftime('%d/%m/%Y') }}</td>
+        <td>{{ adjunto.uploaded_at|fecha(False) }}</td>
         <td class="text-end">
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('adjuntos.detalle', adjunto_id=adjunto.id) }}">Ver</a>
           <a class="btn btn-sm btn-outline-primary" href="{{ url_for('adjuntos.descargar', adjunto_id=adjunto.id) }}">Descargar</a>

--- a/app/templates/auditoria/index.html
+++ b/app/templates/auditoria/index.html
@@ -66,7 +66,7 @@
     <tbody>
       {% for log in pagination.items %}
         <tr>
-          <td>{{ log.created_at.strftime('%d/%m/%Y %H:%M') if log.created_at else '' }}</td>
+          <td>{{ log.created_at|fecha(True) if log.created_at else '' }}</td>
           <td>{{ log.usuario.nombre if log.usuario else 'Sistema' }}</td>
           <td>{{ log.hospital.nombre if log.hospital else '-' }}</td>
           <td>{{ log.modulo or '-' }}</td>

--- a/app/templates/docscan/formulario.html
+++ b/app/templates/docscan/formulario.html
@@ -8,7 +8,7 @@
   <div class="row g-3">
     {{ render_field(form.titulo, form_group_class='col-md-6') }}
     {{ render_select(form.tipo, form_group_class='col-md-3') }}
-    {{ render_field(form.fecha_documento, form_group_class='col-md-3', input_class='form-control', input_type='date') }}
+    {{ render_field(form.fecha_documento, form_group_class='col-md-3', input_class='form-control', input_type='text') }}
     {{ render_select(form.hospital_id, form_group_class='col-md-4') }}
     {{ render_select(form.servicio_id, form_group_class='col-md-4') }}
     {{ render_select(form.oficina_id, form_group_class='col-md-4') }}

--- a/app/templates/docscan/listar.html
+++ b/app/templates/docscan/listar.html
@@ -27,7 +27,7 @@
         <td>{{ doc.titulo }}</td>
         <td class="text-capitalize">{{ normalize_enum_value(doc.tipo) }}</td>
         <td>{{ doc.hospital.nombre if doc.hospital else '—' }}</td>
-        <td>{{ doc.uploaded_at.strftime('%d/%m/%Y') }}</td>
+        <td>{{ doc.uploaded_at|fecha(False) }}</td>
         <td class="text-end">
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('docscan.detalle', doc_id=doc.id) }}">Ver</a>
           <a class="btn btn-sm btn-outline-primary" href="{{ url_for('docscan.descargar', doc_id=doc.id) }}">Descargar</a>

--- a/app/templates/equipos/_form.html
+++ b/app/templates/equipos/_form.html
@@ -120,9 +120,9 @@
       {{ render_textarea(form.descripcion, form_group_class='col-12', rows=3, placeholder='Descripción breve del equipo') }}
       {{ render_field(form.marca, form_group_class='col-12 col-md-4', placeholder='Marca') }}
       {{ render_field(form.modelo, form_group_class='col-12 col-md-4', placeholder='Modelo') }}
-      {{ render_field(form.fecha_ingreso, form_group_class='col-12 col-md-4', input_type='date') }}
-      {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='date') }}
-      {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='date') }}
+      {{ render_field(form.fecha_ingreso, form_group_class='col-12 col-md-4', input_type='text') }}
+      {{ render_field(form.fecha_instalacion, form_group_class='col-12 col-md-4', input_type='text') }}
+      {{ render_field(form.garantia_hasta, form_group_class='col-12 col-md-4', input_type='text') }}
       {{ render_textarea(form.observaciones, form_group_class='col-12', rows=3, placeholder='Observaciones relevantes') }}
     </div>
   </div>

--- a/app/templates/equipos/actas.html
+++ b/app/templates/equipos/actas.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% from '_form_helpers.html' import render_select, render_field %}
+{% from '_pagination.html' import render_pagination %}
 {% set query_args = request.args.to_dict(flat=True) %}
 {% block title %}Actas vinculadas{% endblock %}
 {% block header_title %}Actas vinculadas{% endblock %}
@@ -9,8 +10,8 @@
 </div>
 <form method="get" class="row g-3 mb-3 align-items-end">
   {{ render_select(form.tipo, form_group_class='col-12 col-md-4') }}
-  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='date') }}
-  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='date') }}
+  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='text') }}
+  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='text') }}
   <div class="col-12 col-md-2 d-flex gap-2">
     {{ form.submit(class='btn btn-primary flex-grow-1') }}
     <a class="btn btn-outline-secondary" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id) }}">Limpiar</a>
@@ -23,7 +24,7 @@
       <li class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-start gap-2">
         <div>
           <strong>{{ normalize_enum_value(acta.tipo)|title }}</strong>
-          <div class="text-muted small">{{ acta.fecha.strftime('%d/%m/%Y') }}</div>
+          <div class="text-muted small">{{ acta.fecha|fecha }}</div>
         </div>
         <div class="d-flex align-items-center gap-2">
           {% if acta.numero %}
@@ -38,33 +39,5 @@
     </ul>
   </div>
 </div>
-{% if pagination.pages > 1 %}
-<nav class="mt-3" aria-label="Actas paginación">
-  <ul class="pagination">
-    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
-      {% if pagination.has_prev %}
-      <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': pagination.prev_num})) }}">Anterior</a>
-      {% else %}
-      <span class="page-link">Anterior</span>
-      {% endif %}
-    </li>
-    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-      {% if page_num %}
-        <li class="page-item{% if page_num == pagination.page %} active{% endif %}">
-          <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': page_num})) }}">{{ page_num }}</a>
-        </li>
-      {% else %}
-        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-      {% endif %}
-    {% endfor %}
-    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
-      {% if pagination.has_next %}
-      <a class="page-link" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id, **query_args|combine({'page': pagination.next_num})) }}">Siguiente</a>
-      {% else %}
-      <span class="page-link">Siguiente</span>
-      {% endif %}
-    </li>
-  </ul>
-</nav>
-{% endif %}
+{{ render_pagination(pagination) }}
 {% endblock %}

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from '_pagination.html' import render_pagination %}
 {% block title %}Detalle de equipo{% endblock %}
 {% block content %}
 {% set equipo_titulo = equipo.titulo %}
@@ -6,6 +7,7 @@
 {% set estado_clases = {
   'OPERATIVO': 'status-badge--success',
   'SERVICIO_TECNICO': 'status-badge--warning',
+  'EN_TALLER': 'status-badge--info',
   'DE_BAJA': 'status-badge--danger',
   'PRESTADO': 'status-badge--secondary'
 } %}
@@ -76,7 +78,7 @@
     <div class="card h-100">
       <div class="card-body">
         <h6 class="text-muted">Fechas</h6>
-        <p class="mb-0">Ingreso: {{ equipo.fecha_ingreso or '—' }}<br>Instalación: {{ equipo.fecha_instalacion or '—' }}<br>Garantía: {{ equipo.garantia_hasta or '—' }}</p>
+        <p class="mb-0">Ingreso: {{ equipo.fecha_ingreso|fecha }}<br>Instalación: {{ equipo.fecha_instalacion|fecha }}<br>Garantía: {{ equipo.garantia_hasta|fecha }}</p>
       </div>
     </div>
   </div>
@@ -97,6 +99,14 @@
           <dt class="col-6">Tipo adquisición</dt>
           <dd class="col-6">{{ equipo.tipo_adquisicion|replace('_', ' ')|title if equipo.tipo_adquisicion else '—' }}</dd>
         </dl>
+      </div>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="card h-100">
+      <div class="card-body">
+        <h6 class="text-muted">Observaciones</h6>
+        <p class="mb-0 pre-wrap">{{ equipo.observaciones or 'Sin observaciones registradas.' }}</p>
       </div>
     </div>
   </div>
@@ -125,11 +135,11 @@
               </tr>
             </thead>
             <tbody>
-              {% for asignacion in insumos %}
+              {% for asignacion in insumos_pagination.items %}
               <tr data-insumo-row data-serie-id="{{ asignacion.serie.id }}">
                 <td>{{ asignacion.insumo.nombre }}</td>
                 <td class="font-monospace">{{ asignacion.serie.nro_serie }}</td>
-                <td>{{ asignacion.fecha_asociacion.strftime('%d/%m/%Y %H:%M') if asignacion.fecha_asociacion else '—' }}</td>
+                <td>{{ asignacion.fecha_asociacion|fecha(True) if asignacion.fecha_asociacion else '—' }}</td>
                 <td>{{ asignacion.asociado_por.nombre if asignacion.asociado_por else '—' }}</td>
                 {% if current_user.has_permission('inventario:write') %}
                 <td class="text-end">
@@ -146,6 +156,11 @@
           </table>
         </div>
       </div>
+      {% if insumos_pagination.pages > 1 %}
+      <div class="card-footer bg-transparent">
+        {{ render_pagination(insumos_pagination, param_name='insumos_page') }}
+      </div>
+      {% endif %}
     </div>
   </div>
   <div class="col-md-6">
@@ -158,7 +173,7 @@
             <span class="fw-semibold">{{ adjunto.filename }}</span>
             <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('adjuntos.descargar', adjunto_id=adjunto.id) }}">Descargar</a>
           </div>
-          <small class="text-muted">{{ normalize_enum_value(adjunto.tipo)|title }} · {{ adjunto.created_at.strftime('%d/%m/%Y %H:%M') if adjunto.created_at else '' }}</small>
+          <small class="text-muted">{{ normalize_enum_value(adjunto.tipo)|title }} · {{ adjunto.created_at|fecha(True) if adjunto.created_at else '' }}</small>
         </li>
         {% else %}
         <li class="list-group-item text-muted">No hay documentos adjuntos.</li>
@@ -182,149 +197,98 @@
     </form>
   </div>
   <div class="card-body">
-    <div class="row g-3">
-      {% for archivo in archivos %}
-      <div class="col-12 col-md-6 col-lg-4">
-        <div class="card h-100 shadow-sm">
+    {% if evidencias_pagination.items %}
+    <div class="evidencias-grid">
+      {% for archivo in evidencias_pagination.items %}
+      <article class="evidencia-card">
+        <div class="evidencia-thumb-wrapper">
           {% if archivo.mime_type.startswith('image/') %}
-          <div class="ratio ratio-4x3">
-            <img src="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" alt="{{ archivo.filename }}" class="w-100 h-100 object-fit-cover rounded-top">
-          </div>
-          {% elif archivo.mime_type == 'application/pdf' %}
-          <div class="ratio ratio-4x3 bg-light border-bottom">
-            <object data="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" type="application/pdf" class="w-100 h-100 rounded-top">PDF</object>
-          </div>
+          <img src="{{ url_for('files.thumbnail', file_id=archivo.id) }}" alt="{{ archivo.filename }}" class="evidencia-thumb">
           {% else %}
-          <div class="d-flex align-items-center justify-content-center py-4 bg-light border-bottom">
-            <span class="fw-semibold text-secondary">Archivo</span>
+          <div class="evidencia-placeholder">
+            <span class="fw-semibold">{{ archivo.mime_type.split('/')[-1]|upper if archivo.mime_type else 'FILE' }}</span>
           </div>
           {% endif %}
-          <div class="card-body d-flex flex-column gap-2">
-            <div class="small fw-semibold" title="{{ archivo.filename }}">{{ archivo.filename }}</div>
-            <div class="text-muted small">
-              {{ humanize_bytes(archivo.size_in_bytes()) }} · {{ archivo.mime_type or 'application/octet-stream' }} ·
-              {{ archivo.created_at.strftime('%d/%m/%Y %H:%M') if archivo.created_at else '' }}
-            </div>
-            <div class="d-flex flex-wrap gap-2">
-              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}">Descargar</a>
-              <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('equipos.descargar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id, preview=1) }}" target="_blank" rel="noopener">Ver</a>
-              <form method="post" action="{{ url_for('equipos.eliminar_adjunto', equipo_id=equipo.id, adjunto_id=archivo.id) }}" onsubmit="return confirm('¿Eliminar adjunto?');">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button class="btn btn-sm btn-outline-danger" type="submit">Eliminar</button>
-              </form>
-            </div>
+        </div>
+        <div class="evidencia-body">
+          <div class="evidencia-name" title="{{ archivo.filename }}">{{ archivo.filename }}</div>
+          <div class="text-muted small">
+            {{ humanize_bytes(archivo.size_in_bytes()) }} · {{ archivo.mime_type or 'application/octet-stream' }} · {{ archivo.created_at|fecha(True) if archivo.created_at else '' }}
+          </div>
+          <div class="d-flex flex-wrap gap-2">
+            <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('files.view_file', file_id=archivo.id) }}" target="_blank" rel="noopener">Ver</a>
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('files.download_file', file_id=archivo.id) }}">Descargar</a>
+            <form method="post" action="{{ url_for('files.delete_file', file_id=archivo.id) }}" onsubmit="return confirm('¿Eliminar adjunto?');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="next" value="{{ request.full_path }}">
+              <button class="btn btn-sm btn-outline-danger" type="submit">Eliminar</button>
+            </form>
           </div>
         </div>
-      </div>
-      {% else %}
-      <div class="col-12">
-        <div class="alert alert-light border mb-0">No hay adjuntos cargados.</div>
-      </div>
+      </article>
       {% endfor %}
     </div>
+    {% else %}
+    <div class="alert alert-light border mb-0">No hay adjuntos cargados.</div>
+    {% endif %}
   </div>
+  {% if evidencias_pagination.pages > 1 %}
+  <div class="card-footer bg-transparent">
+    {{ render_pagination(evidencias_pagination, param_name='evidencias_page') }}
+  </div>
+  {% endif %}
 </div>
 <div class="row g-3 mt-3">
   <div class="col-md-6">
     <div class="card h-100">
       <div class="card-header d-flex justify-content-between align-items-center">
-        <span>Historial reciente</span>
-        <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#historialPanel" aria-expanded="false" aria-controls="historialPanel">Ver más</button>
+        <span>Historial</span>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id) }}">Ver todo</a>
       </div>
       <ul class="list-group list-group-flush mb-0">
-        {% for entrada in historial %}
+        {% for entrada in historial_pagination.items %}
         <li class="list-group-item">
-          <strong>{{ entrada.accion }}</strong><br>
-          {{ entrada.descripcion or '' }}<br>
-          <small class="text-muted">{{ entrada.fecha }}{% if entrada.usuario %} · {{ entrada.usuario.nombre }}{% endif %}</small>
+          <div class="d-flex justify-content-between align-items-start">
+            <span class="fw-semibold">{{ entrada.accion }}</span>
+            <small class="text-muted">{{ entrada.fecha|fecha(True) if entrada.fecha else '' }}</small>
+          </div>
+          {% if entrada.descripcion %}
+          <p class="mb-1 small pre-wrap">{{ entrada.descripcion }}</p>
+          {% endif %}
+          <div class="small text-muted">{{ entrada.usuario.nombre if entrada.usuario else '—' }}</div>
         </li>
         {% else %}
         <li class="list-group-item text-muted">Sin movimientos registrados.</li>
         {% endfor %}
       </ul>
-      <div class="collapse border-top" id="historialPanel" data-remote-panel="historial" data-endpoint="{{ url_for('equipos.historial_datos', equipo_id=equipo.id) }}" data-limit="5">
-        <div class="p-3">
-          <form class="row g-2 align-items-end" data-panel-form>
-            <div class="col-12">
-              <label class="form-label small" for="historialTipo">Tipo</label>
-              <input type="text" class="form-control form-control-sm" id="historialTipo" placeholder="Acción o descripción" data-filter="tipo">
-            </div>
-            <div class="col-6">
-              <label class="form-label small" for="historialDesde">Desde</label>
-              <input type="date" class="form-control form-control-sm" id="historialDesde" data-filter="desde">
-            </div>
-            <div class="col-6">
-              <label class="form-label small" for="historialHasta">Hasta</label>
-              <input type="date" class="form-control form-control-sm" id="historialHasta" data-filter="hasta">
-            </div>
-            <div class="col-12 d-flex gap-2">
-              <button class="btn btn-sm btn-primary" type="submit">Aplicar</button>
-              <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-reset>Limpiar</button>
-            </div>
-          </form>
-          <div class="mt-3" data-panel-results>
-            <div class="text-muted small">Sin resultados cargados.</div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mt-3 d-none" data-panel-pagination>
-            <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-prev disabled>Anterior</button>
-            <div class="text-muted small" data-panel-summary>Mostrando 0 de 0</div>
-            <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-next disabled>Siguiente</button>
-          </div>
-        </div>
+      {% if historial_pagination.pages > 1 %}
+      <div class="card-footer bg-transparent">
+        {{ render_pagination(historial_pagination, param_name='historial_page') }}
       </div>
+      {% endif %}
     </div>
   </div>
   <div class="col-md-6">
     <div class="card h-100">
       <div class="card-header d-flex justify-content-between align-items-center">
         <span>Actas vinculadas</span>
-        <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#actasPanel" aria-expanded="false" aria-controls="actasPanel">Ver más</button>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('equipos.actas_completas', equipo_id=equipo.id) }}">Ver todo</a>
       </div>
       <ul class="list-group list-group-flush mb-0">
-        {% for acta in actas %}
+        {% for acta in actas_pagination.items %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ normalize_enum_value(acta.tipo)|title }} - {{ acta.fecha.strftime('%d/%m/%Y') }}</span>
+          <span>{{ normalize_enum_value(acta.tipo)|title }} - {{ acta.fecha|fecha }}</span>
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('actas.detalle', acta_id=acta.id) }}">Ver</a>
         </li>
         {% else %}
         <li class="list-group-item text-muted">Sin actas relacionadas.</li>
         {% endfor %}
       </ul>
-      <div class="collapse border-top" id="actasPanel" data-remote-panel="actas" data-endpoint="{{ url_for('equipos.actas_datos', equipo_id=equipo.id) }}" data-limit="5">
-        <div class="p-3">
-          <form class="row g-2 align-items-end" data-panel-form>
-            <div class="col-12">
-              <label class="form-label small" for="actasTipo">Tipo</label>
-              <select class="form-select form-select-sm" id="actasTipo" data-filter="tipo">
-                <option value="">Todos</option>
-                {% for tipo in tipos_acta %}
-                <option value="{{ tipo.value }}">{{ normalize_enum_value(tipo)|title }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="col-6">
-              <label class="form-label small" for="actasDesde">Desde</label>
-              <input type="date" class="form-control form-control-sm" id="actasDesde" data-filter="desde">
-            </div>
-            <div class="col-6">
-              <label class="form-label small" for="actasHasta">Hasta</label>
-              <input type="date" class="form-control form-control-sm" id="actasHasta" data-filter="hasta">
-            </div>
-            <div class="col-12 d-flex gap-2">
-              <button class="btn btn-sm btn-primary" type="submit">Aplicar</button>
-              <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-reset>Limpiar</button>
-            </div>
-          </form>
-          <div class="mt-3" data-panel-results>
-            <div class="text-muted small">Sin resultados cargados.</div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mt-3 d-none" data-panel-pagination>
-            <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-prev disabled>Anterior</button>
-            <div class="text-muted small" data-panel-summary>Mostrando 0 de 0</div>
-            <button class="btn btn-sm btn-outline-secondary" type="button" data-panel-next disabled>Siguiente</button>
-          </div>
-        </div>
+      {% if actas_pagination.pages > 1 %}
+      <div class="card-footer bg-transparent">
+        {{ render_pagination(actas_pagination, param_name='actas_page') }}
       </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/app/templates/equipos/historial.html
+++ b/app/templates/equipos/historial.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% from '_form_helpers.html' import render_field %}
+{% from '_pagination.html' import render_pagination %}
 {% set query_args = request.args.to_dict(flat=True) %}
 {% block title %}Historial del equipo{% endblock %}
 {% block header_title %}Historial del equipo{% endblock %}
@@ -9,8 +10,8 @@
 </div>
 <form method="get" class="row g-3 mb-3 align-items-end">
   {{ render_field(form.accion, form_group_class='col-12 col-md-4', placeholder='Filtrar por acción o descripción') }}
-  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='date') }}
-  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='date') }}
+  {{ render_field(form.fecha_desde, form_group_class='col-6 col-md-3', input_type='text') }}
+  {{ render_field(form.fecha_hasta, form_group_class='col-6 col-md-3', input_type='text') }}
   <div class="col-12 col-md-2 d-flex gap-2">
     {{ form.submit(class='btn btn-primary flex-grow-1') }}
     <a class="btn btn-outline-secondary" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id) }}">Limpiar</a>
@@ -29,7 +30,7 @@
             {% endif %}
           </div>
           <div class="text-muted small text-md-end">
-            {{ registro.fecha.strftime('%d/%m/%Y %H:%M') if registro.fecha else '' }}
+            {{ registro.fecha|fecha(True) if registro.fecha else '' }}
             {% if registro.usuario %}<br>Por {{ registro.usuario.nombre }}{% endif %}
           </div>
         </div>
@@ -40,33 +41,5 @@
     </ul>
   </div>
 </div>
-{% if pagination.pages > 1 %}
-<nav class="mt-3" aria-label="Historial paginación">
-  <ul class="pagination">
-    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
-      {% if pagination.has_prev %}
-      <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': pagination.prev_num})) }}">Anterior</a>
-      {% else %}
-      <span class="page-link">Anterior</span>
-      {% endif %}
-    </li>
-    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-      {% if page_num %}
-        <li class="page-item{% if page_num == pagination.page %} active{% endif %}">
-          <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': page_num})) }}">{{ page_num }}</a>
-        </li>
-      {% else %}
-        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-      {% endif %}
-    {% endfor %}
-    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
-      {% if pagination.has_next %}
-      <a class="page-link" href="{{ url_for('equipos.historial_completo', equipo_id=equipo.id, **query_args|combine({'page': pagination.next_num})) }}">Siguiente</a>
-      {% else %}
-      <span class="page-link">Siguiente</span>
-      {% endif %}
-    </li>
-  </ul>
-</nav>
-{% endif %}
+{{ render_pagination(pagination) }}
 {% endblock %}

--- a/app/templates/licencias/calendario.html
+++ b/app/templates/licencias/calendario.html
@@ -5,7 +5,7 @@
 <h1 class="h3 mb-4">Calendario de licencias aprobadas</h1>
 <form method="get" class="row g-3 mb-4" novalidate>
   {{ form.hidden_tag() }}
-  {{ render_field(form.mes, form_group_class='col-md-4', input_class='form-control', input_type='date') }}
+  {{ render_field(form.mes, form_group_class='col-md-4', input_class='form-control', input_type='text') }}
   <div class="col-md-3 d-flex align-items-end">
     {{ form.submit(class='btn btn-outline-primary w-100') }}
   </div>

--- a/app/templates/licencias/detalle.html
+++ b/app/templates/licencias/detalle.html
@@ -6,12 +6,12 @@
   <div class="card-body">
     <p><strong>Empleado:</strong> {{ licencia.usuario.nombre }}</p>
     <p><strong>Hospital:</strong> {{ licencia.hospital.nombre if licencia.hospital else '—' }}</p>
-    <p><strong>Período:</strong> {{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} - {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</p>
+    <p><strong>Período:</strong> {{ licencia.fecha_inicio|fecha }} - {{ licencia.fecha_fin|fecha }}</p>
     <p><strong>Tipo:</strong> {{ normalize_enum_value(licencia.tipo)|title }}</p>
     <p><strong>Estado:</strong> {{ normalize_enum_value(licencia.estado) }}</p>
     <p><strong>Motivo:</strong> {{ licencia.motivo }}</p>
     {% if licencia.decisor %}
-    <p><strong>Gestionado por:</strong> {{ licencia.decisor.nombre }} el {{ licencia.decidido_en.strftime('%d/%m/%Y %H:%M') if licencia.decidido_en else '—' }}</p>
+    <p><strong>Gestionado por:</strong> {{ licencia.decisor.nombre }} el {{ licencia.decidido_en|fecha(True) if licencia.decidido_en else '—' }}</p>
     {% endif %}
     <a class="btn btn-outline-secondary" href="{{ url_for('licencias.listar') }}">Volver</a>
   </div>

--- a/app/templates/licencias/gestion.html
+++ b/app/templates/licencias/gestion.html
@@ -19,10 +19,10 @@
         {{ render_select(form.estado, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
       </div>
       <div class="col-6 col-lg-2">
-        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='text') }}
       </div>
       <div class="col-6 col-lg-2">
-        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='text') }}
       </div>
       <div class="col-12 col-lg-2 d-flex gap-2">
         {{ form.submit(class_='btn btn-primary btn-sm flex-grow-1') }}
@@ -58,12 +58,12 @@
               <div class="text-muted small">{{ licencia.usuario.email }}</div>
             </td>
             <td>{{ licencia.hospital.nombre if licencia.hospital else '—' }}</td>
-            <td>{{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} – {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</td>
+            <td>{{ licencia.fecha_inicio|fecha }} – {{ licencia.fecha_fin|fecha }}</td>
             <td>{{ normalize_enum_value(licencia.tipo) }}</td>
             <td data-license-status>
               <span class="badge bg-{{ badge_for(licencia.estado) }}">{{ normalize_enum_value(licencia.estado) }}</span>
               {% if licencia.decisor %}
-              <div class="small text-muted mt-1">{{ licencia.decisor.nombre }}{% if licencia.decidido_en %}, {{ licencia.decidido_en.strftime('%d/%m/%Y %H:%M') }}{% endif %}</div>
+              <div class="small text-muted mt-1">{{ licencia.decisor.nombre }}{% if licencia.decidido_en %}, {{ licencia.decidido_en|fecha(True) }}{% endif %}</div>
               {% endif %}
             </td>
             <td class="text-wrap" data-license-detail>

--- a/app/templates/licencias/listar.html
+++ b/app/templates/licencias/listar.html
@@ -44,7 +44,7 @@
       <tr>
         <td>{{ licencia.usuario.nombre }}</td>
         <td>{{ licencia.hospital.nombre if licencia.hospital else '—' }}</td>
-        <td>{{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} - {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</td>
+        <td>{{ licencia.fecha_inicio|fecha }} - {{ licencia.fecha_fin|fecha }}</td>
         <td class="text-capitalize">{{ normalize_enum_value(licencia.estado) }}</td>
         <td class="text-end">
           <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('licencias.detalle', licencia_id=licencia.id) }}">Detalle</a>

--- a/app/templates/licencias/mias.html
+++ b/app/templates/licencias/mias.html
@@ -16,10 +16,10 @@
         {{ render_select(form.tipo, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-select form-select-sm') }}
       </div>
       <div class="col-6 col-md-2">
-        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+        {{ render_field(form.fecha_desde, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='text') }}
       </div>
       <div class="col-6 col-md-2">
-        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='date') }}
+        {{ render_field(form.fecha_hasta, form_group_class='mb-0', label_class='form-label fw-semibold', input_class='form-control form-control-sm', input_type='text') }}
       </div>
       <div class="col-12 col-md-2 d-flex gap-2">
         {{ form.submit(class_='btn btn-primary btn-sm flex-grow-1') }}
@@ -49,7 +49,7 @@
           <tr data-license-row="{{ licencia.id }}">
             <td class="fw-semibold">{{ normalize_enum_value(licencia.tipo) }}</td>
             <td>
-              <div>{{ licencia.fecha_inicio.strftime('%d/%m/%Y') }} – {{ licencia.fecha_fin.strftime('%d/%m/%Y') }}</div>
+              <div>{{ licencia.fecha_inicio|fecha }} – {{ licencia.fecha_fin|fecha }}</div>
               <div class="text-muted small">{{ licencia.dias_habiles() }} días hábiles</div>
             </td>
             <td>{{ licencia.hospital.nombre if licencia.hospital else '—' }}</td>
@@ -64,7 +64,7 @@
               <div class="text-danger">{{ licencia.motivo_rechazo }}</div>
               {% endif %}
               {% if licencia.decisor %}
-              <div class="small text-muted mt-2">Decidido por {{ licencia.decisor.nombre }}{% if licencia.decidido_en %} el {{ licencia.decidido_en.strftime('%d/%m/%Y %H:%M') }}{% endif %}</div>
+              <div class="small text-muted mt-2">Decidido por {{ licencia.decisor.nombre }}{% if licencia.decidido_en %} el {{ licencia.decidido_en|fecha(True) }}{% endif %}</div>
               {% endif %}
             </td>
             <td class="text-end" data-license-actions>

--- a/app/templates/licencias/nueva.html
+++ b/app/templates/licencias/nueva.html
@@ -14,10 +14,10 @@
           {{ render_select(form.tipo, label_class='form-label fw-semibold', input_class='form-select') }}
           <div class="row g-3">
             <div class="col-sm-6">
-              {{ render_field(form.fecha_inicio, label_class='form-label fw-semibold', input_class='form-control', input_type='date') }}
+              {{ render_field(form.fecha_inicio, label_class='form-label fw-semibold', input_class='form-control', input_type='text') }}
             </div>
             <div class="col-sm-6">
-              {{ render_field(form.fecha_fin, label_class='form-label fw-semibold', input_class='form-control', input_type='date') }}
+              {{ render_field(form.fecha_fin, label_class='form-label fw-semibold', input_class='form-control', input_type='text') }}
             </div>
           </div>
           {{ render_select(form.hospital_id, label_class='form-label fw-semibold', input_class='form-select') }}

--- a/app/templates/licencias/solicitar.html
+++ b/app/templates/licencias/solicitar.html
@@ -6,8 +6,8 @@
 <form method="post" class="row g-3" novalidate>
   {{ form.hidden_tag() }}
   {{ render_select(form.tipo, form_group_class='col-md-4') }}
-  {{ render_field(form.fecha_inicio, form_group_class='col-md-4', input_class='form-control', input_type='date') }}
-  {{ render_field(form.fecha_fin, form_group_class='col-md-4', input_class='form-control', input_type='date') }}
+  {{ render_field(form.fecha_inicio, form_group_class='col-md-4', input_class='form-control', input_type='text') }}
+  {{ render_field(form.fecha_fin, form_group_class='col-md-4', input_class='form-control', input_type='text') }}
   {{ render_textarea(form.motivo, form_group_class='col-12', rows=3) }}
   <div class="col-12">
     {{ form.submit(class="btn btn-primary") }}

--- a/config.py
+++ b/config.py
@@ -103,7 +103,7 @@ class Config:
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
     LOG_FILE: str | None = os.getenv("LOG_FILE")
 
-    DEFAULT_PAGE_SIZE: int = int(os.getenv("DEFAULT_PAGE_SIZE", 20))
+    DEFAULT_PAGE_SIZE: int = int(os.getenv("DEFAULT_PAGE_SIZE", 25))
     DASHBOARD_CACHE_TIMEOUT: int = int(os.getenv("DASHBOARD_CACHE_TIMEOUT", 300))
 
     WEASYPRINT_BASE_URL: str = os.getenv("WEASYPRINT_BASE_URL", str(BASE_DIR))

--- a/migrations/versions/0004_equipos_observaciones_en_taller.py
+++ b/migrations/versions/0004_equipos_observaciones_en_taller.py
@@ -1,0 +1,108 @@
+"""Add observaciones column and new estado for equipos."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0004_equipos_observaciones_en_taller"
+down_revision = "0003_insumo_series_equipo_insumos"
+branch_labels = None
+depends_on = None
+
+
+ESTADO_VALUES = ("operativo", "servicio_tecnico", "de_baja", "prestado")
+NEW_ESTADO = "en_taller"
+
+
+def _add_enum_value() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE estado_equipo ADD VALUE IF NOT EXISTS '%s'" % NEW_ESTADO)
+
+
+def _insert_catalog_state() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in inspector.get_table_names():
+        if "estado" not in table_name or "equipo" not in table_name:
+            continue
+        columns = inspector.get_columns(table_name)
+        column_names = {col["name"]: col for col in columns}
+        insert_data: dict[str, object] = {}
+        if "nombre" in column_names:
+            insert_data["nombre"] = "En taller"
+        if "slug" in column_names:
+            insert_data["slug"] = NEW_ESTADO
+        if "valor" in column_names and "nombre" not in insert_data:
+            insert_data["valor"] = NEW_ESTADO
+        if not insert_data:
+            continue
+        non_nullable = {
+            name
+            for name, col in column_names.items()
+            if not col.get("nullable", True)
+            and col.get("default") is None
+            and col.get("server_default") is None
+            and name not in {"id", "created_at", "updated_at"}
+        }
+        if not non_nullable.issubset(set(insert_data.keys())):
+            continue
+        if "activo" in column_names and "activo" not in insert_data:
+            insert_data["activo"] = True
+        table = sa.table(
+            table_name,
+            *(sa.column(name) for name in insert_data.keys()),
+        )
+        lookup_columns = [key for key in insert_data.keys() if key in {"nombre", "slug", "valor"}]
+        if lookup_columns:
+            condition = " OR ".join(f"{col} = :{col}" for col in lookup_columns)
+            params = {col: insert_data[col] for col in lookup_columns}
+            existing = bind.execute(
+                sa.text(f"SELECT 1 FROM {table_name} WHERE {condition} LIMIT 1"),
+                params,
+            ).first()
+            if existing:
+                continue
+        op.bulk_insert(table, [insert_data])
+
+
+def _remove_catalog_state() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in inspector.get_table_names():
+        if "estado" not in table_name or "equipo" not in table_name:
+            continue
+        columns = inspector.get_columns(table_name)
+        column_names = {col["name"] for col in columns}
+        if "nombre" in column_names:
+            op.execute(sa.text(f"DELETE FROM {table_name} WHERE nombre = :nombre"), {"nombre": "En taller"})
+        elif "valor" in column_names:
+            op.execute(sa.text(f"DELETE FROM {table_name} WHERE valor = :valor"), {"valor": NEW_ESTADO})
+
+
+def upgrade() -> None:
+    op.add_column("equipos", sa.Column("observaciones", sa.Text(), nullable=True))
+    _add_enum_value()
+    _insert_catalog_state()
+
+
+def downgrade() -> None:
+    _remove_catalog_state()
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE estado_equipo RENAME TO estado_equipo_old")
+        sa.Enum(*ESTADO_VALUES, name="estado_equipo").create(bind)
+        op.execute(
+            """
+            ALTER TABLE equipos
+            ALTER COLUMN estado
+            TYPE estado_equipo
+            USING (
+                CASE WHEN estado::text = :nuevo THEN :fallback ELSE estado::text END
+            )::estado_equipo
+            """,
+            {"nuevo": NEW_ESTADO, "fallback": "servicio_tecnico"},
+        )
+        op.execute("DROP TYPE estado_equipo_old")
+    op.drop_column("equipos", "observaciones")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary~=2.9
 gunicorn>=21.2
 pytest>=7.4
 email-validator>=2.1
+Pillow>=10.0


### PR DESCRIPTION
## Resumen
- agregar blueprint de archivos con rutas para ver, descargar, eliminar y miniaturas de evidencias
- mostrar evidencias de equipos como grilla responsive con miniaturas y acciones de gestión
- estandarizar el formato de fechas y aplicar paginación reutilizable en listados, incluyendo nuevo estado "En taller" y campo de observaciones
- crear servicio para generación de thumbnails con fallback y migración para observaciones/estado

## Pruebas
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df04538848832493b90f1422408ac7